### PR TITLE
Implement step 1.5 audit constraints

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -94,19 +94,39 @@ Each entry is tied to a step from the implementation index.
 
 ---
 
-## \[Phase 1 - Step 1.5] – Credit Limit Enforcement
 
-**Status:** ⏳ Pending
+## [Phase 1 - Step 1.5] – Audit Fields & Data Constraints
 
-### 🟩 Features
+**Status:** ✅ Done
 
-* Add `check_credit_limit()` trigger to block sales over credit cap
-* Mark constraint as `DEFERRABLE INITIALLY DEFERRED`
+### 🟦 Enhancements
+
+* Added audit timestamp columns to all tenant tables
+* Introduced NOT NULL and CHECK constraints for schema integrity
+* Created `scripts/check-constraints.ts` for verification
 
 ### Files
 
-* `tenant_schema_template.sql`
+* `migrations/tenant_schema_template.sql`
+* `scripts/check-constraints.ts`
+
+> 🧠 Add a new block here after completing each step. Include test results if relevant.
 
 ---
 
-> 🧠 Add a new block here after completing each step. Include test results if relevant.
+## [Fix - 2025-06-21] – TypeScript Dependency Declarations
+
+**Status:** ✅ Done
+
+### 🟦 Enhancements
+
+* Added `@types/node`, `@types/pg`, and `@types/dotenv` to development dependencies
+* Updated `tsconfig.json` with Node module resolution and types
+* Cleaned TypeScript warnings in `scripts/check-constraints.ts`
+
+### Files
+
+* `package.json`
+* `tsconfig.json`
+* `scripts/check-constraints.ts`
+* `docs/STEP_fix_20250621.md`

--- a/docs/DATABASE_GUIDE.md
+++ b/docs/DATABASE_GUIDE.md
@@ -38,6 +38,10 @@ This guide documents the database structure, key constraints, naming patterns, a
 All constraints are `ON DELETE CASCADE`.
 
 ---
+## 📝 Audit Fields & Data Constraints
+
+All tenant tables include `created_at` and `updated_at` columns with `NOW()` defaults. Business rules are enforced with `NOT NULL` and `CHECK` constraints. Example checks include `reading > 0`, `price_per_litre > 0`, and `credit_limit >= 0`. Stations are unique per tenant and daily reconciliations enforce a unique `(station_id, reconciled_on)` pair.
+
 
 ## ⚠️ Constraint Notes
 

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -15,7 +15,8 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 1     | 1.2  | Tenant Schema Template       | ✅ Done | `tenant_schema_template.sql`, `scripts/seed-tenant-schema.ts` | `PHASE_1_SUMMARY.md#step-1.2` |
 | 1     | 1.3  | Schema Validation Script     | ✅ Done | `scripts/validate-tenant-schema.ts` | `PHASE_1_SUMMARY.md#step-1.3` |
 | 1     | 1.4  | ERD Definition               | ✅ Done | `scripts/generate_erd_image.py`, `docs/DATABASE_GUIDE.md` | `PHASE_1_SUMMARY.md#step-1.4` |
-| 1     | 1.5  | Credit Limit Enforcement     | ⏳ Pending | `tenant_schema_template.sql`           | `PHASE_1_SUMMARY.md#step-1.5` |
+| 1     | 1.5  | Audit Fields & Constraints | ✅ Done | `tenant_schema_template.sql`, `scripts/check-constraints.ts` | `PHASE_1_SUMMARY.md#step-1.5` |
+| fix   | 2025-06-21 | TypeScript Dependency Declarations | ✅ Done | `package.json`, `tsconfig.json` | `docs/STEP_fix_20250621.md` |
 | 2     | 2.1  | Auth: JWT + Roles            | ⏳ Pending | `auth.controller.ts`, middleware files | `PHASE_2_SUMMARY.md#step-2.1` |
 | 2     | 2.2  | Delta Sale Service           | ⏳ Pending | `sale.service.ts`, `sale.test.ts`      | `PHASE_2_SUMMARY.md#step-2.2` |
 | 2     | 2.3  | Sales + Creditors API Routes | ⏳ Pending | `routes/v1/`, OpenAPI spec             | `PHASE_2_SUMMARY.md#step-2.3` |

--- a/docs/PHASE_1_SUMMARY.md
+++ b/docs/PHASE_1_SUMMARY.md
@@ -120,24 +120,18 @@ Each step includes:
 
 ---
 
-### 🧱 Step 1.5 – Credit Limit Enforcement
+### 🧱 Step 1.5 – Audit Fields & Data Constraints
 
-**Status:** ⏳ Pending
-**Files:** `tenant_schema_template.sql`
+**Status:** ✅ Done
+**Files:** `tenant_schema_template.sql`, `scripts/check-constraints.ts`
 
-**Constraint Added:**
+**Overview:**
+* Added `created_at`, `updated_at` TIMESTAMPTZ columns across all tables
+* Enforced NOT NULL and CHECK constraints for key columns
+* Stations unique per tenant; pumps require station; nozzles store number and fuel type
 
-* `check_credit_limit()` BEFORE INSERT ON `sales`
+**Validations Performed:**
+* `scripts/check-constraints.ts` reports missing audit fields or constraints
 
-**Business Rules Covered:**
-
-* Block credit sale if balance exceeds limit
-
-**Validations To Perform:**
-
-* Trigger uses current `creditor_id` balance
-* DEFERRABLE INITIALLY DEFERRED is set
-
----
 
 > ✍️ Update each block once the step is implemented. Add test coverage, design notes, or assumptions as needed.

--- a/docs/STEP_fix_20250621.md
+++ b/docs/STEP_fix_20250621.md
@@ -1,0 +1,19 @@
+# STEP_fix_20250621.md — Resolve TypeScript Dependency Errors
+
+## 🧠 Project Context
+FuelSync Hub scripts are written in TypeScript. `npx tsc --noEmit` failed because type packages were missing.
+
+## ✅ Prior Steps Implemented
+- **Step 1.5**: Audit Fields & Data Constraints
+
+## 🛠 Task: Add missing type dependencies
+- Install `@types/node`, `@types/pg`, and `@types/dotenv` via `package.json`
+- Update `tsconfig.json` to load Node types
+- Fix `scripts/check-constraints.ts` implicit `any` errors
+
+## 📓 Documentation Updates
+- `CHANGELOG.md` → Record dependency additions
+- `IMPLEMENTATION_INDEX.md` → Add fix step row
+
+## ✅ Acceptance Criteria
+- `npx tsc --noEmit` runs without unresolved module errors (after installing deps)

--- a/migrations/tenant_schema_template.sql
+++ b/migrations/tenant_schema_template.sql
@@ -9,39 +9,43 @@ CREATE TABLE IF NOT EXISTS {{schema_name}}.users (
     email TEXT NOT NULL UNIQUE,
     password_hash TEXT NOT NULL,
     role TEXT NOT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE IF NOT EXISTS {{schema_name}}.stations (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     tenant_id UUID REFERENCES public.tenants(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(tenant_id, name)
 );
 
 CREATE TABLE IF NOT EXISTS {{schema_name}}.pumps (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     tenant_id UUID REFERENCES public.tenants(id) ON DELETE CASCADE,
-    station_id UUID REFERENCES {{schema_name}}.stations(id) ON DELETE CASCADE,
+    station_id UUID NOT NULL REFERENCES {{schema_name}}.stations(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE IF NOT EXISTS {{schema_name}}.nozzles (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     tenant_id UUID REFERENCES public.tenants(id) ON DELETE CASCADE,
     pump_id UUID REFERENCES {{schema_name}}.pumps(id) ON DELETE CASCADE,
-    name TEXT NOT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    nozzle_number INTEGER NOT NULL,
+    fuel_type TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE IF NOT EXISTS {{schema_name}}.user_stations (
     user_id UUID REFERENCES {{schema_name}}.users(id) ON DELETE CASCADE,
     station_id UUID REFERENCES {{schema_name}}.stations(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (user_id, station_id)
 );
 
@@ -49,10 +53,10 @@ CREATE TABLE IF NOT EXISTS {{schema_name}}.nozzle_readings (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     tenant_id UUID REFERENCES public.tenants(id) ON DELETE CASCADE,
     nozzle_id UUID REFERENCES {{schema_name}}.nozzles(id) ON DELETE CASCADE,
-    reading NUMERIC NOT NULL,
+    reading NUMERIC NOT NULL CHECK (reading > 0),
     recorded_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX IF NOT EXISTS idx_readings_nozzle_date
@@ -63,50 +67,56 @@ CREATE TABLE IF NOT EXISTS {{schema_name}}.sales (
     tenant_id UUID REFERENCES public.tenants(id) ON DELETE CASCADE,
     nozzle_reading_id UUID REFERENCES {{schema_name}}.nozzle_readings(id) ON DELETE CASCADE,
     user_id UUID REFERENCES {{schema_name}}.users(id) ON DELETE CASCADE,
-    volume NUMERIC NOT NULL,
-    price NUMERIC NOT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    volume NUMERIC NOT NULL CHECK (volume > 0),
+    price_per_litre NUMERIC NOT NULL CHECK (price_per_litre > 0),
+    sale_amount NUMERIC NOT NULL CHECK (sale_amount > 0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE IF NOT EXISTS {{schema_name}}.fuel_prices (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     tenant_id UUID REFERENCES public.tenants(id) ON DELETE CASCADE,
-    station_id UUID REFERENCES {{schema_name}}.stations(id) ON DELETE CASCADE,
+    station_id UUID NOT NULL REFERENCES {{schema_name}}.stations(id) ON DELETE CASCADE,
     price NUMERIC NOT NULL CHECK (price > 0),
     effective_from TIMESTAMP NOT NULL,
     effective_to TIMESTAMP,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE IF NOT EXISTS {{schema_name}}.creditors (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     tenant_id UUID REFERENCES public.tenants(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
-    credit_limit NUMERIC NOT NULL DEFAULT 0,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    contact_person TEXT NOT NULL,
+    email TEXT NOT NULL,
+    credit_limit NUMERIC NOT NULL CHECK (credit_limit >= 0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE IF NOT EXISTS {{schema_name}}.credit_payments (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     tenant_id UUID REFERENCES public.tenants(id) ON DELETE CASCADE,
     creditor_id UUID REFERENCES {{schema_name}}.creditors(id) ON DELETE CASCADE,
-    amount NUMERIC NOT NULL,
+    amount NUMERIC NOT NULL CHECK (amount > 0),
+    reference_number TEXT,
     paid_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    credited_by UUID REFERENCES {{schema_name}}.users(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE IF NOT EXISTS {{schema_name}}.fuel_deliveries (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     tenant_id UUID REFERENCES public.tenants(id) ON DELETE CASCADE,
     station_id UUID REFERENCES {{schema_name}}.stations(id) ON DELETE CASCADE,
-    volume NUMERIC NOT NULL,
+    litres_delivered NUMERIC NOT NULL CHECK (litres_delivered > 0),
+    supplier TEXT NOT NULL,
     delivered_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE IF NOT EXISTS {{schema_name}}.fuel_inventory (
@@ -115,8 +125,8 @@ CREATE TABLE IF NOT EXISTS {{schema_name}}.fuel_inventory (
     station_id UUID REFERENCES {{schema_name}}.stations(id) ON DELETE CASCADE,
     volume NUMERIC NOT NULL,
     recorded_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE IF NOT EXISTS {{schema_name}}.day_reconciliations (
@@ -126,7 +136,8 @@ CREATE TABLE IF NOT EXISTS {{schema_name}}.day_reconciliations (
     reconciled_on DATE NOT NULL,
     total_sales NUMERIC NOT NULL,
     finalized BOOLEAN NOT NULL DEFAULT FALSE,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(station_id, reconciled_on)
 );
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "typescript": "^5.3.3",
     "ts-node": "^10.9.1",
     "pg": "^8.11.0",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "@types/node": "^20.8.10",
+    "@types/pg": "^8.6.7",
+    "@types/dotenv": "^8.2.0"
   }
 }

--- a/scripts/check-constraints.ts
+++ b/scripts/check-constraints.ts
@@ -1,0 +1,76 @@
+import { Client } from 'pg';
+
+const schema = process.argv[2];
+if (!schema) {
+  console.error('Usage: ts-node check-constraints.ts <schema>');
+  process.exit(1);
+}
+
+const NOT_NULL: Record<string, string[]> = {
+  stations: ['name'],
+  pumps: ['station_id'],
+  nozzles: ['nozzle_number', 'fuel_type'],
+  nozzle_readings: ['nozzle_id', 'recorded_at'],
+  fuel_prices: ['station_id'],
+  creditors: ['contact_person', 'email'],
+  fuel_deliveries: ['supplier'],
+};
+
+const CHECKS: Record<string, string[]> = {
+  nozzle_readings: ['reading > 0'],
+  sales: ['volume > 0', 'price_per_litre > 0', 'sale_amount > 0'],
+  fuel_prices: ['price > 0'],
+  creditors: ['credit_limit >= 0'],
+  credit_payments: ['amount > 0'],
+  fuel_deliveries: ['litres_delivered > 0'],
+};
+
+async function main() {
+  const client = new Client();
+  await client.connect();
+
+  const { rows: tables } = await client.query<{ table_name: string }>(
+    `SELECT table_name FROM information_schema.tables WHERE table_schema=$1`,
+    [schema]
+  );
+
+  for (const { table_name } of tables) {
+    const { rows: cols } = await client.query<{ column_name: string; is_nullable: string }>(
+      `SELECT column_name, is_nullable FROM information_schema.columns WHERE table_schema=$1 AND table_name=$2`,
+      [schema, table_name]
+    );
+    const colMap: Record<string, string> = {};
+    for (const c of cols) colMap[c.column_name] = c.is_nullable;
+    if (!('created_at' in colMap)) {
+      console.log(`${table_name}: missing created_at`);
+    }
+    if (!('updated_at' in colMap)) {
+      console.log(`${table_name}: missing updated_at`);
+    }
+    for (const col of NOT_NULL[table_name] || []) {
+      if (colMap[col] !== 'NO') {
+        console.log(`${table_name}.${col} should be NOT NULL`);
+      }
+    }
+    const { rows: checks } = await client.query(
+      `SELECT pg_get_constraintdef(c.oid) as def FROM pg_constraint c
+       JOIN pg_class t ON c.conrelid = t.oid
+       JOIN pg_namespace n ON t.relnamespace = n.oid
+       WHERE n.nspname=$1 AND t.relname=$2 AND c.contype='c'`,
+      [schema, table_name]
+    );
+    const defs = checks.map((r: { def: string }) => r.def);
+    for (const expr of CHECKS[table_name] || []) {
+      if (!defs.some((d: string) => d.includes(expr))) {
+        console.log(`${table_name}: missing CHECK ${expr}`);
+      }
+    }
+  }
+
+  await client.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,9 @@
     "module": "CommonJS",
     "outDir": "dist",
     "esModuleInterop": true,
-    "strict": true
+    "strict": true,
+    "moduleResolution": "node",
+    "types": ["node"]
   },
   "include": ["scripts/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- enforce audit timestamps and constraints in tenant schema
- provide script to verify constraint presence
- document audit rules across docs and changelog
- add missing TS type dependencies and fix script typings

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68570b2fc48083208d7393090c0de3da