### PR TITLE
Add demo tenant seeding scripts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -112,6 +112,22 @@ Each entry is tied to a step from the implementation index.
 
 > 🧠 Add a new block here after completing each step. Include test results if relevant.
 
+## [Phase 1 - Step 1.6] – Dev/Test Tenant Seeder
+
+**Status:** ✅ Done
+
+### 🟩 Features
+
+* Added `seed-demo-tenant.ts` to generate a demo tenant with users, station, pump and nozzles
+* Added `reset-all-demo-tenants.ts` to drop and reseed all `demo_` schemas
+* New npm scripts `seed:demo` and `reset:demo`
+
+### Files
+
+* `scripts/seed-demo-tenant.ts`
+* `scripts/reset-all-demo-tenants.ts`
+* `package.json`
+
 ---
 
 ## [Fix - 2025-06-21] – TypeScript Dependency Declarations

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -16,6 +16,7 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 1     | 1.3  | Schema Validation Script     | ✅ Done | `scripts/validate-tenant-schema.ts` | `PHASE_1_SUMMARY.md#step-1.3` |
 | 1     | 1.4  | ERD Definition               | ✅ Done | `scripts/generate_erd_image.py`, `docs/DATABASE_GUIDE.md` | `PHASE_1_SUMMARY.md#step-1.4` |
 | 1     | 1.5  | Audit Fields & Constraints | ✅ Done | `tenant_schema_template.sql`, `scripts/check-constraints.ts` | `PHASE_1_SUMMARY.md#step-1.5` |
+| 1     | 1.6  | Dev/Test Tenant Seeder      | ✅ Done | `scripts/seed-demo-tenant.ts`, `scripts/reset-all-demo-tenants.ts` | `PHASE_1_SUMMARY.md#step-1.6` |
 | fix   | 2025-06-21 | TypeScript Dependency Declarations | ✅ Done | `package.json`, `tsconfig.json` | `docs/STEP_fix_20250621.md` |
 | 2     | 2.1  | Auth: JWT + Roles            | ⏳ Pending | `auth.controller.ts`, middleware files | `PHASE_2_SUMMARY.md#step-2.1` |
 | 2     | 2.2  | Delta Sale Service           | ⏳ Pending | `sale.service.ts`, `sale.test.ts`      | `PHASE_2_SUMMARY.md#step-2.2` |

--- a/docs/PHASE_1_SUMMARY.md
+++ b/docs/PHASE_1_SUMMARY.md
@@ -135,3 +135,16 @@ Each step includes:
 
 
 > ✍️ Update each block once the step is implemented. Add test coverage, design notes, or assumptions as needed.
+
+### 🧱 Step 1.6 – Dev/Test Tenant Seed Scripts
+
+**Status:** ✅ Done
+**Files:** `scripts/seed-demo-tenant.ts`, `scripts/reset-all-demo-tenants.ts`
+
+**Overview:**
+* Provides CLI script to create a demo tenant schema with users, station, pump and nozzles
+* Includes reset utility to drop all `demo_` schemas and reseed them
+* Enables consistent dev and CI environment data
+
+**Validations Performed:**
+* Basic FK relationships ensured during seeding

--- a/docs/SEEDING.md
+++ b/docs/SEEDING.md
@@ -41,6 +41,18 @@ ts-node scripts/seed-tenant-schema.ts <tenantId> <schemaName>  # create tenant s
 npm run db:reset       # Drops & re-creates schemas
 ```
 
+## 🚀 Demo Tenant Population
+
+Use the development seeder to create a demo schema with minimal data for testing.
+
+```bash
+npm run seed:demo             # seeds demo_tenant_001
+npm run reset:demo            # drops all demo_ schemas and reseeds them
+```
+
+The script inserts an owner, manager and attendant user, a single station with
+one pump, and two nozzles. A sample fuel price record is also created.
+
 ---
 
 ## 🧪 Validation Seed

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "license": "MIT",
   "scripts": {
     "db:seed": "ts-node scripts/seed-public-schema.ts",
-    "db:migrate": "psql -U postgres -f migrations/001_create_public_schema.sql"
+    "db:migrate": "psql -U postgres -f migrations/001_create_public_schema.sql",
+    "seed:demo": "ts-node scripts/seed-demo-tenant.ts",
+    "reset:demo": "ts-node scripts/reset-all-demo-tenants.ts"
   },
   "devDependencies": {
     "typescript": "^5.3.3",

--- a/scripts/reset-all-demo-tenants.ts
+++ b/scripts/reset-all-demo-tenants.ts
@@ -1,0 +1,38 @@
+import { Client } from 'pg';
+import { spawnSync } from 'child_process';
+import path from 'path';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+async function reset() {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+
+  const { rows } = await client.query(
+    `SELECT schema_name FROM public.tenants WHERE schema_name LIKE 'demo_%'`
+  );
+  const schemas = rows.map((r) => r.schema_name);
+
+  for (const schema of schemas) {
+    await client.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE`);
+    await client.query(`DELETE FROM public.tenants WHERE schema_name=$1`, [schema]);
+    console.log(`Dropped schema ${schema}`);
+  }
+
+  await client.end();
+
+  const script = path.join(__dirname, 'seed-demo-tenant.ts');
+  const names = schemas.length ? schemas : ['demo_tenant_001'];
+  for (const name of names) {
+    const res = spawnSync('ts-node', [script, name], { stdio: 'inherit' });
+    if (res.status !== 0) {
+      process.exit(res.status || 1);
+    }
+  }
+}
+
+reset().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/seed-demo-tenant.ts
+++ b/scripts/seed-demo-tenant.ts
@@ -1,0 +1,93 @@
+import { Client } from 'pg';
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+async function seed() {
+  const schema = process.argv[2] || 'demo_tenant_001';
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+
+  // ensure tenant exists in public.tenants and fetch id
+  const { rows: planRows } = await client.query(
+    `SELECT id FROM public.plans WHERE name='basic' LIMIT 1`
+  );
+  const planId = planRows[0].id;
+  const { rows: tenantRows } = await client.query(
+    `INSERT INTO public.tenants (name, schema_name, plan_id)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (schema_name) DO UPDATE SET name=EXCLUDED.name
+     RETURNING id`,
+    [schema, schema, planId]
+  );
+  const tenantId = tenantRows[0].id;
+
+  // apply tenant schema template
+  const templatePath = path.join(__dirname, '../migrations/tenant_schema_template.sql');
+  const templateSql = fs.readFileSync(templatePath, 'utf8').replace(/{{schema_name}}/g, schema);
+  await client.query(templateSql);
+
+  // users
+  const roles = ['owner', 'manager', 'attendant'];
+  for (const role of roles) {
+    await client.query(
+      `INSERT INTO ${schema}.users (tenant_id, email, password_hash, role)
+       VALUES ($1, $2, 'demo-hash', $3)
+       ON CONFLICT (email) DO NOTHING`,
+      [tenantId, `${role}@${schema}.com`, role]
+    );
+  }
+
+  // station
+  const { rows: stationRows } = await client.query(
+    `INSERT INTO ${schema}.stations (tenant_id, name)
+     VALUES ($1, 'Main Station')
+     ON CONFLICT (tenant_id, name) DO UPDATE SET name=EXCLUDED.name
+     RETURNING id`,
+    [tenantId]
+  );
+  const stationId = stationRows[0].id;
+
+  // pump
+  const { rows: pumpRows } = await client.query(
+    `INSERT INTO ${schema}.pumps (tenant_id, station_id, name)
+     VALUES ($1, $2, 'Pump 1')
+     ON CONFLICT (station_id, name) DO UPDATE SET name=EXCLUDED.name
+     RETURNING id`,
+    [tenantId, stationId]
+  );
+  const pumpId = pumpRows[0].id;
+
+  // nozzles
+  await client.query(
+    `INSERT INTO ${schema}.nozzles (tenant_id, pump_id, nozzle_number, fuel_type)
+     VALUES ($1, $2, 1, 'petrol')
+     ON CONFLICT (pump_id, nozzle_number) DO NOTHING`,
+    [tenantId, pumpId]
+  );
+  await client.query(
+    `INSERT INTO ${schema}.nozzles (tenant_id, pump_id, nozzle_number, fuel_type)
+     VALUES ($1, $2, 2, 'diesel')
+     ON CONFLICT (pump_id, nozzle_number) DO NOTHING`,
+    [tenantId, pumpId]
+  );
+
+  // optional fuel price
+  await client.query(
+    `INSERT INTO ${schema}.fuel_prices (tenant_id, station_id, price, effective_from)
+     VALUES ($1, $2, 100, NOW())
+     ON CONFLICT (station_id, effective_from) DO NOTHING`,
+    [tenantId, stationId]
+  );
+
+  console.log(`Seeded tenant '${schema}' with 3 users, 1 station, 1 pump, 2 nozzles.`);
+
+  await client.end();
+}
+
+seed().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- provide `seed-demo-tenant.ts` and `reset-all-demo-tenants.ts`
- document demo seeding in Phase 1 summary, changelog and index
- add demo seed scripts section in SEEDING guide
- update npm scripts

## Testing
- `npm install`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685711a603b483208a3aa4403e742b78