### PR TITLE
Add demo tenant validation script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -146,3 +146,17 @@ Each entry is tied to a step from the implementation index.
 * `tsconfig.json`
 * `scripts/check-constraints.ts`
 * `docs/STEP_fix_20250621.md`
+
+## [Phase 1 - Step 1.7] – Demo Tenant Validation
+
+**Status:** ✅ Done
+
+### 🟩 Features
+
+* Added `validate-demo-tenant.ts` to verify demo seed integrity
+* `reset-all-demo-tenants.ts` now runs the validation after seeding
+
+### Files
+
+* `scripts/validate-demo-tenant.ts`
+* `scripts/reset-all-demo-tenants.ts`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -17,6 +17,7 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 1     | 1.4  | ERD Definition               | ✅ Done | `scripts/generate_erd_image.py`, `docs/DATABASE_GUIDE.md` | `PHASE_1_SUMMARY.md#step-1.4` |
 | 1     | 1.5  | Audit Fields & Constraints | ✅ Done | `tenant_schema_template.sql`, `scripts/check-constraints.ts` | `PHASE_1_SUMMARY.md#step-1.5` |
 | 1     | 1.6  | Dev/Test Tenant Seeder      | ✅ Done | `scripts/seed-demo-tenant.ts`, `scripts/reset-all-demo-tenants.ts` | `PHASE_1_SUMMARY.md#step-1.6` |
+| 1     | 1.7  | Seed Validation Utility     | ✅ Done | `scripts/validate-demo-tenant.ts` | `PHASE_1_SUMMARY.md#step-1.7` |
 | fix   | 2025-06-21 | TypeScript Dependency Declarations | ✅ Done | `package.json`, `tsconfig.json` | `docs/STEP_fix_20250621.md` |
 | 2     | 2.1  | Auth: JWT + Roles            | ⏳ Pending | `auth.controller.ts`, middleware files | `PHASE_2_SUMMARY.md#step-2.1` |
 | 2     | 2.2  | Delta Sale Service           | ⏳ Pending | `sale.service.ts`, `sale.test.ts`      | `PHASE_2_SUMMARY.md#step-2.2` |

--- a/docs/PHASE_1_SUMMARY.md
+++ b/docs/PHASE_1_SUMMARY.md
@@ -148,3 +148,18 @@ Each step includes:
 
 **Validations Performed:**
 * Basic FK relationships ensured during seeding
+
+### 🧱 Step 1.7 – Seed Validation Utility
+
+**Status:** ✅ Done
+**Files:** `scripts/validate-demo-tenant.ts`, `scripts/reset-all-demo-tenants.ts`
+
+**Overview:**
+* Adds a CLI script to verify seeded demo tenant data
+* Ensures users, stations, pumps and nozzles are present and correctly linked
+* `reset-all-demo-tenants.ts` now runs validation after reseeding
+
+**Validations Performed:**
+* Confirms 3 user roles exist
+* Checks station → pump → nozzle relations and counts
+

--- a/docs/SEEDING.md
+++ b/docs/SEEDING.md
@@ -66,4 +66,18 @@ one pump, and two nozzles. A sample fuel price record is also created.
 
 ---
 
+
+## ✅ Seed Validation
+
+Run the validation script to ensure the demo tenant data is consistent:
+
+```bash
+ts-node scripts/validate-demo-tenant.ts <schema_name>
+```
+
+`reset-all-demo-tenants.ts` automatically runs this check after reseeding. The script
+verifies that the three user roles exist and that stations, pumps and nozzles are correctly linked.
+
+---
+
 > After each new module (e.g., reconciliations), extend the seed script accordingly and log in `CHANGELOG.md`.

--- a/docs/STEP_1_7_COMMAND.md
+++ b/docs/STEP_1_7_COMMAND.md
@@ -50,10 +50,10 @@ This step lays the groundwork for CI environments and local dev resets.
 
 ## 📓 Documentation Updates
 
-* [ ] `PHASE_1_SUMMARY.md` → Add validation strategy
-* [ ] `CHANGELOG.md` → Feature: seed validation tool
-* [ ] `IMPLEMENTATION_INDEX.md` → Add step 1.7 row
-* [ ] `SEEDING.md` → Add validation procedure section
+* [x] `PHASE_1_SUMMARY.md` → Add validation strategy
+* [x] `CHANGELOG.md` → Feature: seed validation tool
+* [x] `IMPLEMENTATION_INDEX.md` → Add step 1.7 row
+* [x] `SEEDING.md` → Add validation procedure section
 
 ---
 

--- a/scripts/reset-all-demo-tenants.ts
+++ b/scripts/reset-all-demo-tenants.ts
@@ -22,12 +22,17 @@ async function reset() {
 
   await client.end();
 
-  const script = path.join(__dirname, 'seed-demo-tenant.ts');
+  const seedScript = path.join(__dirname, 'seed-demo-tenant.ts');
+  const validateScript = path.join(__dirname, 'validate-demo-tenant.ts');
   const names = schemas.length ? schemas : ['demo_tenant_001'];
   for (const name of names) {
-    const res = spawnSync('ts-node', [script, name], { stdio: 'inherit' });
+    const res = spawnSync('ts-node', [seedScript, name], { stdio: 'inherit' });
     if (res.status !== 0) {
       process.exit(res.status || 1);
+    }
+    const val = spawnSync('ts-node', [validateScript, name], { stdio: 'inherit' });
+    if (val.status !== 0) {
+      process.exit(val.status || 1);
     }
   }
 }

--- a/scripts/validate-demo-tenant.ts
+++ b/scripts/validate-demo-tenant.ts
@@ -1,0 +1,85 @@
+import { Client } from 'pg';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+function fail(msg: string) {
+  console.error(`\u274c FAILED: ${msg}`); // cross mark
+}
+
+async function main() {
+  const schema = process.argv[2] || 'demo_tenant_001';
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+
+  let hasError = false;
+
+  // Validate users
+  const { rows: userRows } = await client.query<{ role: string }>(
+    `SELECT role FROM ${schema}.users ORDER BY role`
+  );
+  const roles = userRows.map((r) => r.role);
+  if (userRows.length !== 3) {
+    fail(`expected 3 users, found ${userRows.length}`);
+    hasError = true;
+  }
+  const expectedRoles = ['attendant', 'manager', 'owner'];
+  for (const role of expectedRoles) {
+    if (!roles.includes(role)) {
+      fail(`missing user role ${role}`);
+      hasError = true;
+    }
+  }
+
+  // Validate station -> pump -> nozzle hierarchy
+  const { rows: stations } = await client.query<{ id: string }>(
+    `SELECT id FROM ${schema}.stations`
+  );
+  if (stations.length !== 1) {
+    fail(`expected 1 station, found ${stations.length}`);
+    hasError = true;
+  }
+  const stationId = stations[0]?.id;
+
+  const { rows: pumps } = await client.query<{ id: string; station_id: string }>(
+    `SELECT id, station_id FROM ${schema}.pumps`
+  );
+  if (pumps.length !== 1) {
+    fail(`expected 1 pump, found ${pumps.length}`);
+    hasError = true;
+  }
+  const pumpId = pumps[0]?.id;
+  if (pumpId && pumps[0].station_id !== stationId) {
+    fail('pump is not linked to station');
+    hasError = true;
+  }
+
+  const { rows: nozzles } = await client.query<{ pump_id: string }>(
+    `SELECT pump_id FROM ${schema}.nozzles`
+  );
+  if (nozzles.length !== 2) {
+    fail(`expected 2 nozzles, found ${nozzles.length}`);
+    hasError = true;
+  }
+  for (const n of nozzles) {
+    if (n.pump_id !== pumpId) {
+      fail('nozzle not linked to pump');
+      hasError = true;
+      break;
+    }
+  }
+
+  await client.end();
+
+  if (hasError) {
+    console.error('\u274c Demo tenant validation failed');
+    process.exit(1);
+  } else {
+    console.log('\u2705 Demo tenant validation passed');
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `validate-demo-tenant.ts` to verify seeded demo data
- run validation in `reset-all-demo-tenants.ts`
- document validation utility and update summaries
- log step 1.7 in CHANGELOG and implementation index
- update seeding guide

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685712c2f97c83208810aa55c24c4ee3