### PR TITLE
Add credit schema tables

### DIFF
--- a/docs/BUSINESS_RULES.md
+++ b/docs/BUSINESS_RULES.md
@@ -41,9 +41,10 @@ Additional Sale Rules:
 
 | Rule                 | Description                                    |
 | -------------------- | ---------------------------------------------- |
-| **Party Must Exist** | Credit sales require a valid `credit_party_id` |
+| **Party Must Exist** | Credit sales require a valid `creditor_id` |
 | **Max Limit**        | Block new sales if balance > credit\_limit     |
 | **Payment History**  | Recorded in `credit_payments` table            |
+| **Payment Required** | No new credit sales if balance >= credit_limit |
 
 **Suggestion:** Add a `check_credit_limit()` trigger before inserting into `sales`.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -205,3 +205,17 @@ Each entry is tied to a step from the implementation index.
 ### Files
 
 * `migrations/tenant_schema_template.sql`
+
+## [Phase 1 - Step 1.11] – Creditors & Payments Schema
+
+**Status:** ✅ Done
+
+### 🟩 Features
+
+* Expanded `creditors` table with balance and notes fields
+* Added `credit_payments` table with payment_method and received_by columns
+* Linked `sales` to `creditors` via `creditor_id`
+
+### Files
+
+* `migrations/tenant_schema_template.sql`

--- a/docs/DATABASE_GUIDE.md
+++ b/docs/DATABASE_GUIDE.md
@@ -28,7 +28,7 @@ This guide documents the database structure, key constraints, naming patterns, a
 | ----------------- | --------------------------- |
 | `pumps`           | `stations(id)`              |
 | `nozzles`         | `pumps(id)`                 |
-| `sales`           | `nozzles(id)`, `nozzle_readings(id)`, `users(id)` |
+| `sales`           | `nozzles(id)`, `nozzle_readings(id)`, `users(id)`, `creditors(id)` |
 | `user_stations`   | `users(id)`, `stations(id)` |
 | `credit_payments` | `creditors(id)`             |
 | `fuel_deliveries` | `stations(id)`              |

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -21,6 +21,7 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 1     | 1.8  | Plan Limit Enforcement | ✅ Done | `database/plan_constraints.sql`, `src/config/planConfig.ts`, `src/middleware/planEnforcement.ts` | `PHASE_1_SUMMARY.md#step-1.8`
 | 1     | 1.9  | Fuel Pricing Table           | ✅ Done | `migrations/tenant_schema_template.sql`, `src/utils/priceUtils.ts` | `PHASE_1_SUMMARY.md#step-1.9`
 | 1     | 1.10 | Sales Table Schema           | ✅ Done | `migrations/tenant_schema_template.sql` | `PHASE_1_SUMMARY.md#step-1.10`
+| 1     | 1.11 | Creditors & Payments Schema  | ✅ Done | `migrations/tenant_schema_template.sql` | `PHASE_1_SUMMARY.md#step-1.11`
 | fix   | 2025-06-21 | TypeScript Dependency Declarations | ✅ Done | `package.json`, `tsconfig.json` | `docs/STEP_fix_20250621.md` |
 | 2     | 2.1  | Auth: JWT + Roles            | ⏳ Pending | `auth.controller.ts`, middleware files | `PHASE_2_SUMMARY.md#step-2.1` |
 | 2     | 2.2  | Delta Sale Service           | ⏳ Pending | `sale.service.ts`, `sale.test.ts`      | `PHASE_2_SUMMARY.md#step-2.2` |

--- a/docs/PHASE_1_SUMMARY.md
+++ b/docs/PHASE_1_SUMMARY.md
@@ -205,3 +205,16 @@ Each step includes:
 
 **Validations Performed:**
 * CHECK constraints ensure non-negative volume and valid payment methods
+
+### 🧱 Step 1.11 – Creditors & Payments Schema
+
+**Status:** ✅ Done
+**Files:** `migrations/tenant_schema_template.sql`
+
+**Overview:**
+* Expanded `creditors` table with contact info, balance and notes
+* Added `credit_payments` table for recording creditor payments
+* Sales table now links to creditors via `creditor_id`
+
+**Validations Performed:**
+* CHECK constraints for `credit_limit >= 0` and `amount > 0`

--- a/migrations/tenant_schema_template.sql
+++ b/migrations/tenant_schema_template.sql
@@ -68,6 +68,7 @@ CREATE TABLE IF NOT EXISTS {{schema_name}}.sales (
     nozzle_id UUID REFERENCES {{schema_name}}.nozzles(id) ON DELETE CASCADE,
     user_id UUID REFERENCES {{schema_name}}.users(id) ON DELETE CASCADE,
     reading_id UUID REFERENCES {{schema_name}}.nozzle_readings(id) ON DELETE CASCADE,
+    creditor_id UUID REFERENCES {{schema_name}}.creditors(id),
     volume NUMERIC NOT NULL CHECK (volume >= 0),
     price NUMERIC NOT NULL CHECK (price > 0),
     amount NUMERIC GENERATED ALWAYS AS (volume * price) STORED,
@@ -108,10 +109,13 @@ CREATE TABLE IF NOT EXISTS {{schema_name}}.fuel_prices (
 CREATE TABLE IF NOT EXISTS {{schema_name}}.creditors (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     tenant_id UUID REFERENCES public.tenants(id) ON DELETE CASCADE,
-    name TEXT NOT NULL,
-    contact_person TEXT NOT NULL,
-    email TEXT NOT NULL,
-    credit_limit NUMERIC NOT NULL CHECK (credit_limit >= 0),
+    party_name TEXT NOT NULL,
+    contact_person TEXT,
+    contact_phone TEXT,
+    email TEXT,
+    credit_limit NUMERIC CHECK (credit_limit >= 0),
+    balance NUMERIC DEFAULT 0,
+    notes TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
@@ -121,9 +125,11 @@ CREATE TABLE IF NOT EXISTS {{schema_name}}.credit_payments (
     tenant_id UUID REFERENCES public.tenants(id) ON DELETE CASCADE,
     creditor_id UUID REFERENCES {{schema_name}}.creditors(id) ON DELETE CASCADE,
     amount NUMERIC NOT NULL CHECK (amount > 0),
+    payment_method TEXT CHECK (payment_method IN ('cash', 'bank_transfer', 'check')),
     reference_number TEXT,
-    paid_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    credited_by UUID REFERENCES {{schema_name}}.users(id),
+    notes TEXT,
+    received_by UUID REFERENCES {{schema_name}}.users(id),
+    received_at TIMESTAMP NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );


### PR DESCRIPTION
## Summary
- add creditor_id FK to sales
- expand creditors and credit_payments tables
- document credit limit rules
- update ERD and implementation index
- summarize Phase 1 step 1.11 in docs

## Testing
- `npm install`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685717422b5c8320ae8a224cac31d522