### PR TITLE
Add day_reconciliations to tenant schema

### DIFF
--- a/database/tenant_schema_template.sql
+++ b/database/tenant_schema_template.sql
@@ -107,3 +107,20 @@ CREATE TABLE fuel_inventory (
 
 CREATE INDEX ON fuel_inventory(station_id);
 
+CREATE TABLE day_reconciliations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  station_id UUID NOT NULL REFERENCES stations(id) DEFERRABLE INITIALLY DEFERRED,
+  date DATE NOT NULL,
+  total_sales NUMERIC(10,2) DEFAULT 0,
+  cash_total NUMERIC(10,2) DEFAULT 0,
+  card_total NUMERIC(10,2) DEFAULT 0,
+  upi_total NUMERIC(10,2) DEFAULT 0,
+  credit_total NUMERIC(10,2) DEFAULT 0,
+  finalized BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(station_id, date)
+);
+
+CREATE INDEX ON day_reconciliations(station_id);
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -384,3 +384,15 @@ Each entry is tied to a step from the implementation index.
 ### Files
 
 * `database/tenant_schema_template.sql`
+
+## [Phase 1 - Step 1.23] – Daily Reconciliation Table
+
+**Status:** ✅ Done
+
+### 🟩 Features
+
+* Added `day_reconciliations` table to tenant schema
+
+### Files
+
+* `database/tenant_schema_template.sql`

--- a/docs/DATABASE_GUIDE.md
+++ b/docs/DATABASE_GUIDE.md
@@ -107,3 +107,18 @@ These tables were added in **Step 1.22** to support credit sales and fuel stock 
 | `credit_payments`| Records repayments from creditors                  |
 | `fuel_deliveries`| Logs fuel received per station and fuel type       |
 | `fuel_inventory` | Tracks current tank levels after deliveries/sales  |
+
+### 🆕 Day Reconciliation Table
+
+Introduced in **Step 1.23** to capture end-of-day totals per station.
+
+| Field          | Description                           |
+| -------------- | ------------------------------------- |
+| `station_id`   | FK to `stations.id`                   |
+| `date`         | Day being reconciled (unique per station) |
+| `total_sales`  | Aggregate sales amount for the day    |
+| `cash_total`   | Cash payments total                   |
+| `card_total`   | Card payments total                   |
+| `upi_total`    | UPI payments total                    |
+| `credit_total` | Credit sales total                    |
+| `finalized`    | Indicates reconciliation is locked    |

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -34,6 +34,7 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 1     | 1.20 | Basic DB Integrity Tests | ✅ Done | `tests/db.test.ts`, `jest.config.js`, `package.json` | `PHASE_1_SUMMARY.md#step-1.20` |
 | 1     | 1.21 | Tenant Schema SQL Template | ✅ Done | `sql/tenant_schema_template.sql` | `PHASE_1_SUMMARY.md#step-1.21` |
 | 1     | 1.22 | Extended Tenant Tables | ✅ Done | `database/tenant_schema_template.sql` | `PHASE_1_SUMMARY.md#step-1.22` |
+| 1     | 1.23 | Daily Reconciliation Table | ✅ Done | `database/tenant_schema_template.sql` | `PHASE_1_SUMMARY.md#step-1.23` |
 | 2     | 2.1  | Auth: JWT + Roles            | ⏳ Pending | `auth.controller.ts`, middleware files | `PHASE_2_SUMMARY.md#step-2.1` |
 | 2     | 2.2  | Delta Sale Service           | ⏳ Pending | `sale.service.ts`, `sale.test.ts`      | `PHASE_2_SUMMARY.md#step-2.2` |
 | 2     | 2.3  | Sales + Creditors API Routes | ⏳ Pending | `routes/v1/`, OpenAPI spec             | `PHASE_2_SUMMARY.md#step-2.3` |

--- a/docs/PHASE_1_SUMMARY.md
+++ b/docs/PHASE_1_SUMMARY.md
@@ -360,3 +360,16 @@ Each step includes:
 
 **Validations Performed:**
 * Manual review of SQL for constraints and indexes
+
+### 🧱 Step 1.23 – Daily Reconciliation Table
+
+**Status:** ✅ Done
+**Files:** `database/tenant_schema_template.sql`
+
+**Overview:**
+* Added `day_reconciliations` table for per-station daily summaries
+* Tracks totals by payment method with a finalized flag
+* Enforces `UNIQUE(station_id, date)` and DEFERRABLE FK
+
+**Validations Performed:**
+* Manual review of SQL structure and unique constraint


### PR DESCRIPTION
## Summary
- extend `tenant_schema_template.sql` with `day_reconciliations`
- update phase summary with step 1.23 completion
- log the change in `CHANGELOG`
- track new step in `IMPLEMENTATION_INDEX`
- document reconciliation table in `DATABASE_GUIDE`

## Testing
- `npm install`
- `npm test` *(fails: AggregateError)*

------
https://chatgpt.com/codex/tasks/task_e_68572dd4bcd883208dc3e5aa102cf520