### PR TITLE
Add audit_logs table to tenant schema

### DIFF
--- a/database/tenant_schema_template.sql
+++ b/database/tenant_schema_template.sql
@@ -124,3 +124,15 @@ CREATE TABLE day_reconciliations (
 
 CREATE INDEX ON day_reconciliations(station_id);
 
+CREATE TABLE audit_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) DEFERRABLE INITIALLY DEFERRED,
+  action TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id UUID NOT NULL,
+  details JSONB,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX ON audit_logs(entity_type, entity_id);
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -396,3 +396,15 @@ Each entry is tied to a step from the implementation index.
 ### Files
 
 * `database/tenant_schema_template.sql`
+
+## [Phase 1 - Step 1.24] – Audit Logs Table
+
+**Status:** ✅ Done
+
+### 🟩 Features
+
+* Added `audit_logs` table for per-tenant action tracking
+
+### Files
+
+* `database/tenant_schema_template.sql`

--- a/docs/DATABASE_GUIDE.md
+++ b/docs/DATABASE_GUIDE.md
@@ -96,6 +96,7 @@ Generate the diagram locally using `python scripts/generate_erd_image.py`. The o
 | fuel_deliveries        | tenant    | Incoming fuel by station and type      |
 | fuel_inventory         | tenant    | Current stock level per station        |
 | day_reconciliations    | tenant    | Daily summary with payment breakdown and lock flag |
+| audit_logs             | tenant    | User actions and metadata              |
 
 ### 🆕 Credit & Inventory Tables
 
@@ -122,3 +123,15 @@ Introduced in **Step 1.23** to capture end-of-day totals per station.
 | `upi_total`    | UPI payments total                    |
 | `credit_total` | Credit sales total                    |
 | `finalized`    | Indicates reconciliation is locked    |
+
+### 🆕 Audit Logs Table
+
+Introduced in **Step 1.24** to provide a tenant-level audit trail.
+
+| Field         | Description                                         |
+| ------------- | --------------------------------------------------- |
+| `user_id`     | FK to `users.id`                                    |
+| `action`      | Describes the operation performed                   |
+| `entity_type` | Type of record affected (e.g., `sale`)               |
+| `entity_id`   | UUID of the affected record                         |
+| `details`     | Optional JSONB metadata about the action            |

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -35,6 +35,7 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 1     | 1.21 | Tenant Schema SQL Template | ✅ Done | `sql/tenant_schema_template.sql` | `PHASE_1_SUMMARY.md#step-1.21` |
 | 1     | 1.22 | Extended Tenant Tables | ✅ Done | `database/tenant_schema_template.sql` | `PHASE_1_SUMMARY.md#step-1.22` |
 | 1     | 1.23 | Daily Reconciliation Table | ✅ Done | `database/tenant_schema_template.sql` | `PHASE_1_SUMMARY.md#step-1.23` |
+| 1     | 1.24 | Audit Logs Table | ✅ Done | `database/tenant_schema_template.sql` | `PHASE_1_SUMMARY.md#step-1.24` |
 | 2     | 2.1  | Auth: JWT + Roles            | ⏳ Pending | `auth.controller.ts`, middleware files | `PHASE_2_SUMMARY.md#step-2.1` |
 | 2     | 2.2  | Delta Sale Service           | ⏳ Pending | `sale.service.ts`, `sale.test.ts`      | `PHASE_2_SUMMARY.md#step-2.2` |
 | 2     | 2.3  | Sales + Creditors API Routes | ⏳ Pending | `routes/v1/`, OpenAPI spec             | `PHASE_2_SUMMARY.md#step-2.3` |

--- a/docs/PHASE_1_SUMMARY.md
+++ b/docs/PHASE_1_SUMMARY.md
@@ -373,3 +373,17 @@ Each step includes:
 
 **Validations Performed:**
 * Manual review of SQL structure and unique constraint
+
+### 🧱 Step 1.24 – Audit Logs Table
+
+**Status:** ✅ Done
+**Files:** `database/tenant_schema_template.sql`
+
+**Overview:**
+* Added `audit_logs` table to record user actions on tenant data
+* Stores `action`, `entity_type`, `entity_id` and optional JSON details
+* Foreign key to `users` is `DEFERRABLE INITIALLY DEFERRED`
+* Indexed by `(entity_type, entity_id)` for efficient lookups
+
+**Validations Performed:**
+* Manual review of SQL for constraints and index


### PR DESCRIPTION
## Summary
- extend tenant schema template with `audit_logs`
- mark Step 1.24 completed in phase summary
- document audit logs table in the database guide
- log the change in the changelog and implementation index

## Testing
- `npx jest` *(fails: Need to install the following packages: jest@30.0.2)*

------
https://chatgpt.com/codex/tasks/task_e_68572ea7f8b483209c4456f528625a52