### PR TITLE
Implement STEP_2_7 delivery API

### DIFF
--- a/docs/BUSINESS_RULES.md
+++ b/docs/BUSINESS_RULES.md
@@ -111,6 +111,7 @@ authenticateJWT → requireRole(['manager']) → checkStationAccess → route ha
 | Rule | Description |
 | --- | --- |
 | **Delivery Adds Stock** | Each row in `fuel_deliveries` increases `fuel_inventory.current_volume`. |
+| **Inventory Auto Init** | Delivery creates inventory row when missing |
 | **Sale Reduces Stock** | Recorded sales deduct sold volume from `fuel_inventory`. |
 | **Low Stock Alert** | Future enhancement will trigger alerts when below threshold. |
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -547,3 +547,20 @@ Each entry is tied to a step from the implementation index.
 * `src/validators/creditor.validator.ts`
 * `src/services/nozzleReading.service.ts`
 * `src/validators/nozzleReading.validator.ts`
+
+## [Phase 2 - Step 2.7] – Fuel Delivery & Inventory Tracking
+
+**Status:** ✅ Done
+
+### 🟩 Features
+
+* Endpoint `POST /api/fuel-deliveries` to record deliveries
+* Endpoint `GET /api/fuel-deliveries` to list deliveries per tenant
+* Inventory volume auto-increments with each delivery
+
+### Files
+
+* `src/controllers/delivery.controller.ts`
+* `src/services/delivery.service.ts`
+* `src/routes/delivery.route.ts`
+* `src/validators/delivery.validator.ts`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -43,6 +43,7 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 2     | 2.4  | Nozzle Readings & Auto Sales | ✅ Done | `src/controllers/nozzleReading.controller.ts`, `src/routes/nozzleReading.route.ts` | `PHASE_2_SUMMARY.md#step-2.4` |
 | 2     | 2.5  | Fuel Pricing Management | ✅ Done | `src/controllers/fuelPrice.controller.ts`, `src/routes/fuelPrice.route.ts`, `src/services/fuelPrice.service.ts`, `src/validators/fuelPrice.validator.ts` | `PHASE_2_SUMMARY.md#step-2.5` |
 | 2     | 2.6  | Creditors & Credit Sales | ✅ Done | `src/controllers/creditor.controller.ts`, `src/services/creditor.service.ts`, `src/routes/creditor.route.ts`, `src/validators/creditor.validator.ts` | `PHASE_2_SUMMARY.md#step-2.6` |
+| 2     | 2.7  | Fuel Deliveries & Inventory | ✅ Done | `src/controllers/delivery.controller.ts`, `src/services/delivery.service.ts`, `src/routes/delivery.route.ts`, `src/validators/delivery.validator.ts` | `PHASE_2_SUMMARY.md#step-2.7` |
 | 3     | 3.1  | Owner Dashboard UI           | ⏳ Pending | `frontend/app/dashboard/`              | `PHASE_3_SUMMARY.md#step-3.1` |
 | 3     | 3.2  | Manual Reading Entry UI      | ⏳ Pending | `frontend/app/readings/new.tsx`        | `PHASE_3_SUMMARY.md#step-3.2` |
 | 3     | 3.3  | Creditors View + Payments    | ⏳ Pending | `frontend/app/creditors/`              | `PHASE_3_SUMMARY.md#step-3.3` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -137,3 +137,20 @@ Each step includes:
 * Balance updates wrapped in transaction
 
 ---
+
+### 🛠️ Step 2.7 – Fuel Deliveries & Inventory Tracking
+
+**Status:** ✅ Done
+**Files:** `src/controllers/delivery.controller.ts`, `src/services/delivery.service.ts`, `src/routes/delivery.route.ts`, `src/validators/delivery.validator.ts`
+
+**Business Rules Covered:**
+
+* Delivery increases inventory volume
+* Inventory record created if missing
+
+**Validation Performed:**
+
+* Input fields validated for presence and numeric volume
+* Transactional update of delivery and inventory
+
+---

--- a/src/controllers/delivery.controller.ts
+++ b/src/controllers/delivery.controller.ts
@@ -1,0 +1,31 @@
+import { Request, Response } from 'express';
+import { Pool } from 'pg';
+import { createFuelDelivery, listFuelDeliveries } from '../services/delivery.service';
+import { validateCreateDelivery, parseDeliveryQuery } from '../validators/delivery.validator';
+
+export function createDeliveryHandlers(db: Pool) {
+  return {
+    create: async (req: Request, res: Response) => {
+      try {
+        const tenantId = req.user?.tenantId;
+        if (!tenantId) {
+          return res.status(400).json({ status: 'error', message: 'Missing tenant context' });
+        }
+        const data = validateCreateDelivery(req.body);
+        const id = await createFuelDelivery(db, tenantId, data);
+        res.status(201).json({ id });
+      } catch (err: any) {
+        res.status(400).json({ status: 'error', message: err.message });
+      }
+    },
+    list: async (req: Request, res: Response) => {
+      const tenantId = req.user?.tenantId;
+      if (!tenantId) {
+        return res.status(400).json({ status: 'error', message: 'Missing tenant context' });
+      }
+      const query = parseDeliveryQuery(req.query);
+      const deliveries = await listFuelDeliveries(db, tenantId, query);
+      res.json({ deliveries });
+    },
+  };
+}

--- a/src/routes/delivery.route.ts
+++ b/src/routes/delivery.route.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { Pool } from 'pg';
+import { authenticateJWT } from '../middlewares/authenticateJWT';
+import { requireRole } from '../middlewares/requireRole';
+import { UserRole } from '../constants/auth';
+import { createDeliveryHandlers } from '../controllers/delivery.controller';
+
+export function createDeliveryRouter(db: Pool) {
+  const router = Router();
+  const handlers = createDeliveryHandlers(db);
+
+  router.post('/fuel-deliveries', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.create);
+  router.get('/fuel-deliveries', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.list);
+
+  return router;
+}

--- a/src/services/delivery.service.ts
+++ b/src/services/delivery.service.ts
@@ -1,0 +1,55 @@
+import { Pool, PoolClient } from 'pg';
+import { DeliveryInput, DeliveryQuery } from '../validators/delivery.validator';
+
+export async function createFuelDelivery(db: Pool, tenantId: string, input: DeliveryInput): Promise<string> {
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN');
+    const res = await client.query<{ id: string }>(
+      `INSERT INTO ${tenantId}.fuel_deliveries (station_id, fuel_type, volume, delivered_by, delivery_date)
+       VALUES ($1,$2,$3,$4,$5) RETURNING id`,
+      [input.stationId, input.fuelType, input.volume, input.supplier || null, input.deliveryDate]
+    );
+
+    const inv = await client.query<{ id: string }>(
+      `SELECT id FROM ${tenantId}.fuel_inventory WHERE station_id = $1 AND fuel_type = $2`,
+      [input.stationId, input.fuelType]
+    );
+    if (inv.rowCount) {
+      await client.query(
+        `UPDATE ${tenantId}.fuel_inventory
+           SET current_volume = current_volume + $3, updated_at = NOW()
+         WHERE station_id = $1 AND fuel_type = $2`,
+        [input.stationId, input.fuelType, input.volume]
+      );
+    } else {
+      await client.query(
+        `INSERT INTO ${tenantId}.fuel_inventory (station_id, fuel_type, current_volume)
+         VALUES ($1,$2,$3)`,
+        [input.stationId, input.fuelType, input.volume]
+      );
+    }
+    await client.query('COMMIT');
+    return res.rows[0].id;
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+export async function listFuelDeliveries(db: Pool, tenantId: string, query: DeliveryQuery) {
+  const params: any[] = [];
+  let idx = 1;
+  let where = '';
+  if (query.stationId) {
+    where = `WHERE station_id = $${idx++}`;
+    params.push(query.stationId);
+  }
+  const sql = `SELECT id, station_id, fuel_type, volume, delivered_by, delivery_date, created_at
+               FROM ${tenantId}.fuel_deliveries ${where}
+               ORDER BY delivery_date DESC`;
+  const res = await db.query(sql, params);
+  return res.rows;
+}

--- a/src/validators/delivery.validator.ts
+++ b/src/validators/delivery.validator.ts
@@ -1,0 +1,47 @@
+export interface DeliveryInput {
+  stationId: string;
+  fuelType: string;
+  volume: number;
+  supplier?: string;
+  deliveryDate: Date;
+  documentNumber?: string;
+}
+
+export interface DeliveryQuery {
+  stationId?: string;
+}
+
+export function validateCreateDelivery(data: any): DeliveryInput {
+  const { stationId, fuelType, volume, supplier, deliveryDate, documentNumber } = data || {};
+  if (!stationId || typeof stationId !== 'string') {
+    throw new Error('stationId required');
+  }
+  if (!fuelType || typeof fuelType !== 'string') {
+    throw new Error('fuelType required');
+  }
+  const vol = parseFloat(volume);
+  if (isNaN(vol) || vol <= 0) {
+    throw new Error('volume must be > 0');
+  }
+  const date = new Date(deliveryDate);
+  if (!deliveryDate || isNaN(date.getTime())) {
+    throw new Error('deliveryDate invalid');
+  }
+  const result: DeliveryInput = { stationId, fuelType, volume: vol, deliveryDate: date };
+  if (supplier && typeof supplier === 'string') {
+    result.supplier = supplier;
+  }
+  if (documentNumber && typeof documentNumber === 'string') {
+    result.documentNumber = documentNumber;
+  }
+  return result;
+}
+
+export function parseDeliveryQuery(query: any): DeliveryQuery {
+  const { stationId } = query || {};
+  const result: DeliveryQuery = {};
+  if (stationId && typeof stationId === 'string') {
+    result.stationId = stationId;
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- add delivery validator, service, controller and routes
- update business rules for inventory auto init
- record delivery feature in changelog
- mark step complete in Phase 2 summary and implementation index

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: AggregateError)*

------
https://chatgpt.com/codex/tasks/task_e_6857a7326f98832090ef212fb861e87d