### PR TITLE
Add sales listing and tenant settings APIs

### DIFF
--- a/docs/BUSINESS_RULES.md
+++ b/docs/BUSINESS_RULES.md
@@ -117,6 +117,14 @@ authenticateJWT → requireRole(['manager']) → checkStationAccess → route ha
 | **Sale Reduces Stock** | Recorded sales deduct sold volume from `fuel_inventory`. |
 | **Low Stock Alert** | Future enhancement will trigger alerts when below threshold. |
 
+## ⚙ Tenant Settings
+
+| Rule | Description |
+| --- | --- |
+| **Owner Updates** | Only the tenant owner may modify settings via `/v1/settings` |
+| **Manager Read** | Owners and managers can read current preferences |
+| **Fields** | `receipt_template`, `fuel_rounding`, `branding_logo_url` stored in `tenant_settings` |
+
 ---
 
 ## ✅ Record Ownership & Integrity

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -850,3 +850,13 @@ Each entry is tied to a step from the implementation index.
 * Swagger UI accessible at `http://localhost:3000/api/docs`
 * Swagger JSON available at `http://localhost:3000/api/docs/swagger.json`
 * All previously missing routes now properly documented with request/response schemas
+
+## [Step 2.15] – Sales Listing & Tenant Settings API
+
+### 🟩 Features
+* Added GET `/v1/sales` with filtering options
+* Added GET and POST `/v1/settings` for tenant preferences
+
+### Files
+* `src/routes/sales.route.ts`, `src/controllers/sales.controller.ts`, `src/services/sales.service.ts`
+* `src/routes/settings.route.ts`, `src/controllers/settings.controller.ts`, `src/services/settings.service.ts`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -52,6 +52,7 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 2     | 2.13 | Independent Backend Test Execution | ✅ Done | `jest.globalSetup.ts`, `jest.globalTeardown.ts`, `scripts/create-test-db.ts`, `scripts/seed-test-db.ts` | `PHASE_2_SUMMARY.md#step-2.13` |
 | 2     | CRITICAL_FIXES | Critical backend fixes | ✅ Done | `src/db/index.ts`, `migrations/003_add_indexes.sql`, `src/utils/errorResponse.ts`, tests | `docs/STEP_2_CRITICAL_FIXES.md` |
 | 2     | 2.14 | Safe Schema & Indexes | ✅ Done | `src/utils/schemaUtils.ts`, `src/errors/ServiceError.ts`, `migrations/004_add_additional_indexes.sql` | `PHASE_2_SUMMARY.md#step-2.14` |
+| 2     | 2.15 | Sales Listing & Settings API | ✅ Done | `src/routes/sales.route.ts`, `src/controllers/sales.controller.ts`, `src/services/sales.service.ts`, `src/routes/settings.route.ts`, `src/controllers/settings.controller.ts`, `src/services/settings.service.ts` | `PHASE_2_SUMMARY.md#step-2.15` |
 | 3     | 3.1  | Owner Dashboard UI           | ⏳ Pending | `frontend/app/dashboard/`              | `PHASE_3_SUMMARY.md#step-3.1` |
 | 3     | 3.2  | Manual Reading Entry UI      | ⏳ Pending | `frontend/app/readings/new.tsx`        | `PHASE_3_SUMMARY.md#step-3.2` |
 | fix | 2025-06-22 | Local dev setup and seed fixes | ✅ Done | `docs/LOCAL_DEV_SETUP.md` | `docs/STEP_fix_20250622.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -308,3 +308,14 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * UUID generation moved entirely to the backend
 * Removed `uuid-ossp` extension and all `DEFAULT uuid_generate_v4()` clauses
+
+### 🛠️ Step 2.15 – Sales Listing & Tenant Settings API
+
+**Status:** ✅ Done
+**Files:** `src/routes/sales.route.ts`, `src/controllers/sales.controller.ts`, `src/services/sales.service.ts`, `src/routes/settings.route.ts`, `src/controllers/settings.controller.ts`, `src/services/settings.service.ts`
+
+**Overview:**
+* Added `/v1/sales` endpoint with filtering by station, nozzle and date range
+* Added `/v1/settings` GET and POST endpoints for tenant preferences
+* Owner role required to update settings; owners and managers can view
+* Marks completion of Phase 2 backend implementation

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,8 @@ import { createFuelPriceRouter } from './routes/fuelPrice.route';
 import { createCreditorRouter } from './routes/creditor.route';
 import { createDeliveryRouter } from './routes/delivery.route';
 import { createReconciliationRouter } from './routes/reconciliation.route';
+import { createSalesRouter } from './routes/sales.route';
+import { createSettingsRouter } from './routes/settings.route';
 import { errorHandler } from './middlewares/errorHandler';
 
 export function createApp() {
@@ -38,6 +40,8 @@ export function createApp() {
   app.use('/v1/creditors', createCreditorRouter(pool));
   app.use('/v1/fuel-deliveries', createDeliveryRouter(pool));
   app.use('/v1/reconciliation', createReconciliationRouter(pool));
+  app.use('/v1/sales', createSalesRouter(pool));
+  app.use('/v1/settings', createSettingsRouter(pool));
 
   app.use(errorHandler);
   return app;

--- a/src/controllers/sales.controller.ts
+++ b/src/controllers/sales.controller.ts
@@ -1,0 +1,32 @@
+import { Request, Response } from 'express';
+import { Pool } from 'pg';
+import { parseSalesQuery } from '../validators/sales.validator';
+import { listSales } from '../services/sales.service';
+import { errorResponse } from '../utils/errorResponse';
+
+export function createSalesHandlers(db: Pool) {
+  return {
+    list: async (req: Request, res: Response) => {
+      try {
+        const user = req.user;
+        if (!user?.tenantId) {
+          return errorResponse(res, 400, 'Missing tenant context');
+        }
+        const query = parseSalesQuery(req.query);
+        if (query.stationId) {
+          const access = await db.query(
+            `SELECT 1 FROM ${user.tenantId}.user_stations WHERE user_id = $1 AND station_id = $2`,
+            [user.userId, query.stationId]
+          );
+          if (!access.rowCount) {
+            return errorResponse(res, 403, 'Station access denied');
+          }
+        }
+        const sales = await listSales(db, user.tenantId, query);
+        res.json({ sales });
+      } catch (err: any) {
+        return errorResponse(res, 400, err.message);
+      }
+    },
+  };
+}

--- a/src/controllers/settings.controller.ts
+++ b/src/controllers/settings.controller.ts
@@ -1,0 +1,31 @@
+import { Request, Response } from 'express';
+import { Pool } from 'pg';
+import { getTenantSettings, upsertTenantSettings } from '../services/settings.service';
+import { validateUpdateSettings } from '../validators/settings.validator';
+import { errorResponse } from '../utils/errorResponse';
+
+export function createSettingsHandlers(db: Pool) {
+  return {
+    get: async (req: Request, res: Response) => {
+      const tenantId = req.user?.tenantId;
+      if (!tenantId) {
+        return errorResponse(res, 400, 'Missing tenant context');
+      }
+      const settings = await getTenantSettings(db, tenantId);
+      res.json({ settings });
+    },
+    update: async (req: Request, res: Response) => {
+      try {
+        const tenantId = req.user?.tenantId;
+        if (!tenantId) {
+          return errorResponse(res, 400, 'Missing tenant context');
+        }
+        const input = validateUpdateSettings(req.body);
+        await upsertTenantSettings(db, tenantId, input);
+        res.json({ status: 'ok' });
+      } catch (err: any) {
+        return errorResponse(res, 400, err.message);
+      }
+    },
+  };
+}

--- a/src/routes/sales.route.ts
+++ b/src/routes/sales.route.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import { Pool } from 'pg';
+import { authenticateJWT } from '../middlewares/authenticateJWT';
+import { requireRole } from '../middlewares/requireRole';
+import { UserRole } from '../constants/auth';
+import { createSalesHandlers } from '../controllers/sales.controller';
+
+export function createSalesRouter(db: Pool) {
+  const router = Router();
+  const handlers = createSalesHandlers(db);
+
+  router.get('/', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.list);
+
+  return router;
+}

--- a/src/routes/settings.route.ts
+++ b/src/routes/settings.route.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { Pool } from 'pg';
+import { authenticateJWT } from '../middlewares/authenticateJWT';
+import { requireRole } from '../middlewares/requireRole';
+import { UserRole } from '../constants/auth';
+import { createSettingsHandlers } from '../controllers/settings.controller';
+
+export function createSettingsRouter(db: Pool) {
+  const router = Router();
+  const handlers = createSettingsHandlers(db);
+
+  router.get('/', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.get);
+  router.post('/', authenticateJWT, requireRole([UserRole.Owner]), handlers.update);
+
+  return router;
+}

--- a/src/services/sales.service.ts
+++ b/src/services/sales.service.ts
@@ -1,0 +1,33 @@
+import { Pool } from 'pg';
+import { SalesQuery } from '../validators/sales.validator';
+
+export async function listSales(db: Pool, tenantId: string, query: SalesQuery) {
+  const params: any[] = [];
+  const conds: string[] = [];
+  let idx = 1;
+  if (query.nozzleId) {
+    conds.push(`s.nozzle_id = $${idx++}`);
+    params.push(query.nozzleId);
+  }
+  if (query.stationId) {
+    conds.push(`p.station_id = $${idx++}`);
+    params.push(query.stationId);
+  }
+  if (query.startDate) {
+    conds.push(`s.sold_at >= $${idx++}`);
+    params.push(query.startDate);
+  }
+  if (query.endDate) {
+    conds.push(`s.sold_at <= $${idx++}`);
+    params.push(query.endDate);
+  }
+  const where = conds.length ? `WHERE ${conds.join(' AND ')}` : '';
+  const sql = `SELECT s.id, s.nozzle_id, s.user_id, s.volume_sold, s.sale_amount, s.sold_at, s.payment_method
+               FROM ${tenantId}.sales s
+               JOIN ${tenantId}.nozzles n ON s.nozzle_id = n.id
+               JOIN ${tenantId}.pumps p ON n.pump_id = p.id
+               ${where}
+               ORDER BY s.sold_at DESC`;
+  const res = await db.query(sql, params);
+  return res.rows;
+}

--- a/src/services/settings.service.ts
+++ b/src/services/settings.service.ts
@@ -1,0 +1,22 @@
+import { Pool } from 'pg';
+import { SettingsInput } from '../validators/settings.validator';
+
+export async function getTenantSettings(db: Pool, tenantId: string) {
+  const res = await db.query(
+    'SELECT receipt_template, fuel_rounding, branding_logo_url FROM public.tenant_settings WHERE tenant_id = $1',
+    [tenantId]
+  );
+  return res.rows[0] || {};
+}
+
+export async function upsertTenantSettings(db: Pool, tenantId: string, input: SettingsInput) {
+  await db.query(
+    `INSERT INTO public.tenant_settings (tenant_id, receipt_template, fuel_rounding, branding_logo_url)
+     VALUES ($1,$2,$3,$4)
+     ON CONFLICT (tenant_id) DO UPDATE SET
+       receipt_template = COALESCE(EXCLUDED.receipt_template, public.tenant_settings.receipt_template),
+       fuel_rounding = COALESCE(EXCLUDED.fuel_rounding, public.tenant_settings.fuel_rounding),
+       branding_logo_url = COALESCE(EXCLUDED.branding_logo_url, public.tenant_settings.branding_logo_url)`,
+    [tenantId, input.receiptTemplate || null, input.fuelRounding ?? null, input.brandingLogoUrl || null]
+  );
+}

--- a/src/validators/sales.validator.ts
+++ b/src/validators/sales.validator.ts
@@ -1,0 +1,26 @@
+export interface SalesQuery {
+  stationId?: string;
+  nozzleId?: string;
+  startDate?: Date;
+  endDate?: Date;
+}
+
+export function parseSalesQuery(query: any): SalesQuery {
+  const { stationId, nozzleId, startDate, endDate } = query || {};
+  const result: SalesQuery = {};
+  if (stationId && typeof stationId === 'string') {
+    result.stationId = stationId;
+  }
+  if (nozzleId && typeof nozzleId === 'string') {
+    result.nozzleId = nozzleId;
+  }
+  if (startDate) {
+    const d = new Date(startDate);
+    if (!isNaN(d.getTime())) result.startDate = d;
+  }
+  if (endDate) {
+    const d = new Date(endDate);
+    if (!isNaN(d.getTime())) result.endDate = d;
+  }
+  return result;
+}

--- a/src/validators/settings.validator.ts
+++ b/src/validators/settings.validator.ts
@@ -1,0 +1,31 @@
+export interface SettingsInput {
+  receiptTemplate?: string;
+  fuelRounding?: number;
+  brandingLogoUrl?: string;
+}
+
+export function validateUpdateSettings(data: any): SettingsInput {
+  const { receiptTemplate, fuelRounding, brandingLogoUrl } = data || {};
+  const result: SettingsInput = {};
+  if (receiptTemplate && typeof receiptTemplate === 'string') {
+    result.receiptTemplate = receiptTemplate;
+  }
+  if (fuelRounding !== undefined) {
+    const n = parseInt(fuelRounding, 10);
+    if (isNaN(n)) {
+      throw new Error('fuelRounding must be a number');
+    }
+    result.fuelRounding = n;
+  }
+  if (brandingLogoUrl && typeof brandingLogoUrl === 'string') {
+    result.brandingLogoUrl = brandingLogoUrl;
+  }
+  if (
+    result.receiptTemplate === undefined &&
+    result.fuelRounding === undefined &&
+    result.brandingLogoUrl === undefined
+  ) {
+    throw new Error('No update fields');
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- add GET `/v1/sales` endpoint
- add GET/POST `/v1/settings` endpoints
- document new APIs and finalize backend phase

## Testing
- `npm test` *(fails: unable to provision test DB)*

------
https://chatgpt.com/codex/tasks/task_e_68581292c4448320b6763b120254851e