### PR TITLE
Fix dashboard breakdown and daily summary route

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -968,3 +968,16 @@ Each entry is tied to a step from the implementation index.
 * `src/controllers/reconciliation.controller.ts`, `src/routes/reconciliation.route.ts`
 * `src/routes/creditPayment.route.ts`, `src/routes/creditor.route.ts`
 * `src/services/station.service.ts`, `docs/openapi.yaml`, `docs/missing/*`
+
+## [Fix - 2025-07-10] – Dashboard & Reconciliation Bug Fixes
+
+### 🟥 Fixes
+* Corrected route order in reconciliation router so `/daily-summary` works.
+* Unified tenant lookup in dashboard payment method breakdown.
+* Added basic analytics summary endpoint for SuperAdmin.
+
+### Files
+* `src/routes/reconciliation.route.ts`
+* `src/controllers/dashboard.controller.ts`
+* `src/controllers/adminUser.controller.ts`, `src/routes/adminApi.router.ts`
+* `docs/STEP_fix_20250710.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -73,6 +73,7 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-07-07 | Node typings for Azure | ✅ Done | `package.json`, `tsconfig.json` | `docs/STEP_fix_20250707.md` |
 | fix | 2025-07-08 | Azure cleanup | ✅ Done | `package.json`, `app.js`, `src/app.ts` | `docs/STEP_fix_20250708.md` |
 | fix | 2025-07-09 | API alignment | ✅ Done | `src/app.ts`, controllers, routes | `docs/STEP_fix_20250709.md` |
+| fix | 2025-07-10 | Dashboard & recon bugfixes | ✅ Done | `src/routes/reconciliation.route.ts`, `src/controllers/dashboard.controller.ts`, `src/controllers/adminUser.controller.ts`, `src/routes/adminApi.router.ts` | `docs/STEP_fix_20250710.md` |
 | 3     | 3.3  | Creditors View + Payments    | ⏳ Pending | `frontend/app/creditors/`              | `PHASE_3_SUMMARY.md#step-3.3` |
 
 ---

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -400,3 +400,13 @@ sudo apt-get update && sudo apt-get install -y postgresql
 * All frontend-documented endpoints are now available under `/api/v1`.
 * Added dashboard analytics, logout and token refresh, admin analytics and daily reconciliation summary.
 * Credit payment routes aligned and station listing now returns real counts.
+
+### 🛠️ Fix 2025-07-10 – Dashboard & Reconciliation Bug Fixes
+
+**Status:** ✅ Done
+**Files:** `src/routes/reconciliation.route.ts`, `src/controllers/dashboard.controller.ts`, `src/controllers/adminUser.controller.ts`, `src/routes/adminApi.router.ts`
+
+**Overview:**
+* Reordered reconciliation routes so the daily summary endpoint is reachable.
+* Dashboard payment method breakdown now uses `req.user` consistently.
+* Added lightweight analytics summary for SuperAdmin users.

--- a/docs/STEP_fix_20250710.md
+++ b/docs/STEP_fix_20250710.md
@@ -1,0 +1,18 @@
+# STEP_fix_20250710.md — Dashboard & Reconciliation Bug Fixes
+
+## Project Context Summary
+The backend has comprehensive routes and controllers for FuelSync Hub. After recent API alignment, some minor issues remained: a route order causing `/daily-summary` to never match, inconsistent tenant ID retrieval in the dashboard controller, and a missing simple analytics summary for SuperAdmin users.
+
+## Steps Already Implemented
+- Full backend with authentication, reconciliation and dashboard modules.
+- Prior fix on 2025-07-09 aligned all API routes under `/api/v1`.
+
+## What Was Done Now
+- Reordered routes in `reconciliation.route.ts` so `/daily-summary` resolves correctly.
+- Simplified tenant detection in `getPaymentMethodBreakdown`.
+- Added `getAnalytics` helper to `adminUser.controller.ts` and exposed it via `adminApi.router.ts`.
+
+## Required Documentation Updates
+- `CHANGELOG.md` entry for this fix.
+- `PHASE_2_SUMMARY.md` updated with bug details.
+- `IMPLEMENTATION_INDEX.md` appended with this step.

--- a/src/controllers/adminUser.controller.ts
+++ b/src/controllers/adminUser.controller.ts
@@ -19,5 +19,17 @@ export function createAdminUserHandlers(db: Pool) {
       const users = await listAdminUsers(db);
       res.json({ users });
     },
+    getAnalytics: async (_req: Request, res: Response) => {
+      try {
+        const summary = await db.query(`
+          SELECT 
+            (SELECT COUNT(*) FROM public.tenants) as total_tenants,
+            (SELECT COUNT(*) FROM public.tenants WHERE created_at >= CURRENT_DATE - INTERVAL '30 days') as new_tenants
+        `);
+        res.json(summary.rows[0]);
+      } catch (err: any) {
+        return errorResponse(res, 500, err.message);
+      }
+    },
   };
 }

--- a/src/controllers/dashboard.controller.ts
+++ b/src/controllers/dashboard.controller.ts
@@ -48,9 +48,9 @@ export function createDashboardHandlers(db: Pool) {
       }
     },
 
-    getPaymentMethodBreakdown: async (_req: Request, res: Response) => {
+    getPaymentMethodBreakdown: async (req: Request, res: Response) => {
       try {
-        const tenantId = res.locals.user?.tenantId || res.req.user?.tenantId;
+        const tenantId = req.user?.tenantId;
 
         const query = `
           SELECT

--- a/src/routes/adminApi.router.ts
+++ b/src/routes/adminApi.router.ts
@@ -3,11 +3,17 @@ import { Pool } from 'pg';
 import { createAdminUserRouter } from './adminUser.route';
 import { createAdminTenantRouter } from './adminTenant.route';
 import { createAdminAnalyticsRouter } from './adminAnalytics.route';
+import { createAdminUserHandlers } from '../controllers/adminUser.controller';
+import { authenticateJWT } from '../middlewares/authenticateJWT';
+import { requireRole } from '../middlewares/requireRole';
+import { UserRole } from '../constants/auth';
 
 export function createAdminApiRouter(db: Pool) {
   const router = Router();
+  const controller = createAdminUserHandlers(db);
   router.use('/users', createAdminUserRouter(db));
   router.use('/tenants', createAdminTenantRouter(db));
+  router.get('/analytics', authenticateJWT, requireRole([UserRole.SuperAdmin]), controller.getAnalytics);
   router.use('/analytics', createAdminAnalyticsRouter(db));
   return router;
 }

--- a/src/routes/reconciliation.route.ts
+++ b/src/routes/reconciliation.route.ts
@@ -10,8 +10,8 @@ export function createReconciliationRouter(db: Pool) {
   const handlers = createReconciliationHandlers(db);
 
   router.post('/', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.create);
-  router.get('/:stationId', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.get);
   router.get('/daily-summary', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.getDailySummary);
+  router.get('/:stationId', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.get);
 
   return router;
 }


### PR DESCRIPTION
## Summary
- fix route ordering for reconciliation daily summary
- fix tenant lookup in payment method breakdown
- add admin analytics summary endpoint
- document bugfixes in STEP_fix_20250710

## Testing
- `npm test` *(fails: unable to provision test DB)*

------
https://chatgpt.com/codex/tasks/task_e_6859ccaf0d3c8320b3f02ac9795255ca