### PR TITLE
Fix reports controller compile error

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1054,3 +1054,12 @@ Each entry is tied to a step from the implementation index.
 * `src/app.ts`, `docs/openapi.yaml`, `src/docs/swagger.ts`
 * `frontend/docs/integration-instructions.md`, `frontend/docs/api-diff.md`
 * `docs/STEP_2_20_COMMAND.md`
+
+## [Fix - 2025-07-14] – Reports Controller Compile Error
+
+### 🟥 Fixes
+* Removed stray closing brace causing TypeScript error in `createReportsHandlers`.
+
+### Files
+* `src/controllers/reports.controller.ts`
+* `docs/STEP_fix_20250714.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -94,3 +94,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-07-11 | SuperAdmin API Alignment | ✅ Done | `migrations/005_add_price_yearly_to_plans.sql`, `src/services/plan.service.ts`, `src/controllers/admin.controller.ts`, `src/services/tenant.service.ts`, `src/routes/adminApi.router.ts`, `src/controllers/analytics.controller.ts` | `docs/STEP_fix_20250711.md` |
 | fix | 2025-07-12 | Remove Legacy Seeders | ✅ Done | `src/app.ts`, `scripts/setup-database.js`, removed scripts | `docs/STEP_fix_20250712.md` |
 | fix | 2025-07-13 | Document Frontend API Contract | ✅ Done | `frontend/docs/openapi-v1.yaml`, `frontend/docs/api-diff.md` | `docs/STEP_fix_20250713.md` |
+| fix | 2025-07-14 | Reports Controller Compile Fix | ✅ Done | `src/controllers/reports.controller.ts` | `docs/STEP_fix_20250714.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -448,3 +448,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 * Fuel price records can now be updated via `PUT`.
 * Sales reports available via `POST /reports/sales`.
 * OpenAPI docs and Swagger spec updated.
+
+### 🛠️ Fix 2025-07-14 – Reports Controller Compile Fix
+
+**Status:** ✅ Done
+**Files:** `src/controllers/reports.controller.ts`
+
+**Overview:**
+* Removed extra closing brace which stopped `tsc` with error `TS1128`.

--- a/docs/STEP_fix_20250714.md
+++ b/docs/STEP_fix_20250714.md
@@ -1,0 +1,15 @@
+# STEP_fix_20250714.md — Reports Controller Compile Fix
+
+## Project Context Summary
+The backend compilation failed after introducing new analytics and report endpoints. TypeScript threw `TS1128` in `reports.controller.ts` due to an extra closing bracket left over from refactoring.
+
+## Steps Already Implemented
+All backend features up to `STEP_2_20_COMMAND.md` and fixes up to `STEP_fix_20250713.md` are complete.
+
+## What Was Done Now
+- Removed the stray closing brace in `src/controllers/reports.controller.ts` that prematurely ended the `createReportsHandlers` function.
+
+## Required Documentation Updates
+- Add a new entry in `CHANGELOG.md` noting the compile error fix.
+- Update `PHASE_2_SUMMARY.md` under fixes.
+- Append a row to `IMPLEMENTATION_INDEX.md` for this step.

--- a/src/controllers/reports.controller.ts
+++ b/src/controllers/reports.controller.ts
@@ -73,7 +73,6 @@ export function createReportsHandlers(db: Pool) {
         return errorResponse(res, 500, err.message);
       }
     }
-  }
 
   return {
     exportSales: runExportSales,


### PR DESCRIPTION
## Summary
- fix stray closing brace in reports controller
- add compile fix documentation and index entries

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b80f75f1c8320894940771903ce7d