### PR TITLE
Add reusable response components

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1577,3 +1577,10 @@ Each entry is tied to a step from the implementation index.
 * `src/controllers/station.controller.ts`
 * `backend_brain.md`
 * `docs/STEP_2_32_COMMAND.md`
+
+## [Enhancement - 2025-08-03] – Reusable response components
+### 🟦 Enhancements
+* Added shared `Success` and `Error` response objects in the OpenAPI spec.
+### Files
+* `docs/openapi.yaml`
+* `docs/STEP_2_33_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -114,3 +114,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-07-31 | OpenAPI Schema Details | ✅ Done | `docs/openapi.yaml` | `docs/STEP_fix_20250731.md` |
 | 2     | 2.31 | Analytics & GET endpoints | ✅ Done | `src/controllers/analytics.controller.ts`, `src/services/analytics.service.ts`, `src/controllers/alerts.controller.ts`, `src/services/alert.service.ts`, `src/controllers/creditor.controller.ts`, `prisma/schema.prisma`, `docs/openapi.yaml`, `backend_brain.md` | `docs/STEP_2_31_COMMAND.md` |
 | 2     | 2.32 | Parameter naming alignment | ✅ Done | `src/routes/user.route.ts`, `src/routes/station.route.ts`, `docs/openapi.yaml`, `backend_brain.md` | `docs/STEP_2_32_COMMAND.md` |
+| 2     | 2.33 | Reusable response components | ✅ Done | `docs/openapi.yaml` | `docs/STEP_2_33_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -591,3 +591,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * Renamed user and station path parameters to `userId` and `stationId`.
 * Synced OpenAPI documentation and backend brain entries.
+
+### 🛠️ Step 2.33 – Reusable response components
+**Status:** ✅ Done
+**Files:** `docs/openapi.yaml`
+
+**Overview:**
+* Added shared `Success` and `Error` response objects under `components.responses`.

--- a/docs/STEP_2_33_COMMAND.md
+++ b/docs/STEP_2_33_COMMAND.md
@@ -1,0 +1,19 @@
+# STEP_2_33_COMMAND.md — Add response components
+
+## Project Context Summary
+The OpenAPI specification references `#/components/responses/Success` and `#/components/responses/Error` but these components were not defined. Consumers of the API need these reusable objects for consistent code generation.
+
+## Steps Already Implemented
+- Analytics and lookup endpoints (STEP_2_31_COMMAND.md)
+- Parameter naming alignment (STEP_2_32_COMMAND.md)
+
+## What to Build Now
+- Define `Success` and `Error` responses under `components.responses` in `docs/openapi.yaml`.
+- Keep existing security schemes and schemas intact.
+- Document the update in the changelog, phase summary and implementation index.
+
+## Files To Update
+- `docs/openapi.yaml`
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1145,6 +1145,28 @@ components:
       in: header
       name: x-tenant-id
 
+  responses:
+    Success:
+      description: Success response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+    Error:
+      description: Error response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              message:
+                type: string
+
   schemas:
     LoginRequest:
       type: object


### PR DESCRIPTION
## Summary
- define `Success` and `Error` reusable responses in OpenAPI
- document change in CHANGELOG
- add step log and update phase summary & implementation index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d299a81208320aea3d31630f4c752