### PR TITLE
Add missing reporting and reconciliation endpoints

### DIFF
--- a/backend_brain.md
+++ b/backend_brain.md
@@ -50,6 +50,7 @@ This document tracks the current API surface and backend best practices. It is u
 | GET | /api/v1/fuel-deliveries | List fuel deliveries |
 | GET | /api/v1/reconciliation/:stationId | Get reconciliation summary |
 | POST | /api/v1/reconciliation | Run daily reconciliation |
+| GET | /api/v1/reconciliation | Reconciliation history |
 | GET | /api/v1/reconciliation/daily-summary | Daily nozzle reading summary |
 | GET | /api/v1/sales | List sales records |
 | GET | /api/v1/sales/analytics | Sales analytics |
@@ -71,7 +72,11 @@ This document tracks the current API surface and backend best practices. It is u
 | GET | /api/v1/inventory/alerts | Inventory alerts |
 | GET | /api/v1/reports/sales/export | Export sales report |
 | POST | /api/v1/reports/sales | Export sales via POST |
+| GET | /api/v1/reports/sales | Get sales report |
+| POST | /api/v1/reports/export | Export generic report |
+| POST | /api/v1/reports/schedule | Schedule report |
 | GET | /api/v1/reports/financial/export | Export financial report |
+| GET | /api/v1/reconciliation | Reconciliation history |
 | GET | /api/v1/analytics/dashboard | Super admin dashboard analytics |
 | GET | /api/v1/analytics/superadmin | Alias to dashboard analytics |
 | GET | /api/v1/analytics/tenant/:id | Tenant analytics summary |
@@ -134,6 +139,9 @@ const users = await prisma.user.findMany({ where: { tenant_id } });
 | GET | /api/v1/analytics/station-comparison | analytics.controller.ts | no |
 | GET | /api/v1/reports/sales/export | reports.controller.ts | no |
 | POST | /api/v1/reports/sales | reports.controller.ts | no |
+| GET | /api/v1/reports/sales | reports.controller.ts | no |
+| POST | /api/v1/reports/export | reports.controller.ts | no |
+| POST | /api/v1/reports/schedule | reports.controller.ts | no |
 | GET | /api/v1/reports/financial/export | reports.controller.ts | no |
 | GET | /api/v1/alerts/ | alerts.controller.ts | no |
 | PATCH | /api/v1/alerts/:id/read | alerts.controller.ts | no |
@@ -150,6 +158,7 @@ const users = await prisma.user.findMany({ where: { tenant_id } });
 | POST | /api/v1/inventory/update | inventory.controller.ts | no |
 | GET | /api/v1/inventory/alerts | inventory.controller.ts | no |
 | POST | /api/v1/reconciliation/ | reconciliation.controller.ts | no |
+| GET | /api/v1/reconciliation | reconciliation.controller.ts | no |
 | GET | /api/v1/reconciliation/daily-summary | reconciliation.controller.ts | no |
 | GET | /api/v1/reconciliation/:stationId | reconciliation.controller.ts | no |
 | GET | /api/v1/dashboard/sales-summary | dashboard.controller.ts | no |

--- a/db_brain.md
+++ b/db_brain.md
@@ -29,6 +29,7 @@ This document records the reasoning and structure for migrating FuelSync Hub fro
 | `nozzle_readings` | `id`, `tenant_id`, `nozzle_id`, `reading`, `recorded_at`, `payment_method`, `created_at`, `updated_at` |
 | `credit_payments` | `id`, `tenant_id`, `creditor_id`, `amount`, `payment_method`, `reference_number`, `notes`, `received_at`, `created_at`, `updated_at` |
 | `day_reconciliations` | `id`, `tenant_id`, `station_id`, `date`, `total_sales`, `cash_total`, `card_total`, `upi_total`, `credit_total`, `finalized`, `created_at`, `updated_at` |
+| `report_schedules` | `id`, `tenant_id`, `station_id`, `type`, `frequency`, `next_run`, `created_at`, `updated_at` |
 | `audit_logs` | `id`, `tenant_id`, `user_id`, `action`, `entity_type`, `entity_id`, `details`, `created_at`, `updated_at` |
 | `user_activity_logs` | `id`, `tenant_id`, `user_id`, `ip_address`, `user_agent`, `event`, `recorded_at`, `updated_at` |
 | `validation_issues` | `id`, `tenant_id`, `entity_type`, `entity_id`, `message`, `created_at` |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -536,6 +536,37 @@ paths:
                     items:
                       $ref: '#/components/schemas/FuelPerformanceMetric'
   /api/v1/reports/sales:
+    get:
+      summary: Get sales report
+      parameters:
+        - name: stationId
+          in: query
+          schema:
+            type: string
+        - name: dateFrom
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: dateTo
+          in: query
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          description: Sales data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SalesReportData'
+                  summary:
+                    $ref: '#/components/schemas/SalesReportSummary'
     post:
       summary: Export sales report
       responses:
@@ -548,7 +579,43 @@ paths:
         content:
           application/json:
             schema:
-              type: object
+              $ref: '#/components/schemas/ExportReportRequest'
+  /api/v1/reports/export:
+    post:
+      summary: Export report
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExportReportRequest'
+      responses:
+        '200':
+          description: Report file
+        default:
+          $ref: '#/components/responses/Error'
+  /api/v1/reports/schedule:
+    post:
+      summary: Schedule report
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScheduleReportRequest'
+      responses:
+        '200':
+          description: Report scheduled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
   /api/v1/creditors:
     post:
       summary: Create creditor
@@ -668,6 +735,26 @@ paths:
         default:
           $ref: '#/components/responses/Error'
   /api/v1/reconciliation:
+    get:
+      summary: Get reconciliation history
+      parameters:
+        - name: stationId
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Reconciliation records
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ReconciliationRecord'
     post:
       summary: Run daily reconciliation
       responses:
@@ -680,10 +767,21 @@ paths:
         content:
           application/json:
             schema:
-              type: object
+              $ref: '#/components/schemas/CreateReconciliationRequest'
   /api/v1/reconciliation/{stationId}:
     get:
       summary: Get reconciliation summary
+      parameters:
+        - name: stationId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: date
+          in: query
+          required: true
+          schema:
+            type: string
       responses:
         '200':
           $ref: '#/components/responses/Success'

--- a/migrations/schema/004_add_report_schedules.sql
+++ b/migrations/schema/004_add_report_schedules.sql
@@ -1,0 +1,15 @@
+-- Description: add report_schedules table
+BEGIN;
+CREATE TABLE IF NOT EXISTS public.report_schedules (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id),
+    station_id UUID REFERENCES public.stations(id),
+    type TEXT NOT NULL,
+    frequency TEXT NOT NULL,
+    next_run TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_report_schedules_tenant ON public.report_schedules(tenant_id);
+COMMENT ON TABLE public.report_schedules IS 'Scheduled report configuration';
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -166,3 +166,18 @@ model Sale {
   creditor     Creditor? @relation(fields: [creditor_id], references: [id])
   creator      User?    @relation(fields: [created_by], references: [id])
 }
+
+model ReportSchedule {
+  id         String   @id @default(uuid())
+  tenant_id  String
+  station_id String?
+  type       String
+  frequency  String
+  next_run   DateTime?
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
+
+  station    Station? @relation(fields: [station_id], references: [id])
+
+  @@index([tenant_id], name: "idx_report_schedules_tenant")
+}

--- a/src/controllers/reconciliation.controller.ts
+++ b/src/controllers/reconciliation.controller.ts
@@ -3,6 +3,7 @@ import { Pool } from 'pg';
 import {
   runReconciliation,
   getReconciliation,
+  listReconciliations,
 } from '../services/reconciliation.service';
 import { errorResponse } from '../utils/errorResponse';
 
@@ -24,6 +25,19 @@ export function createReconciliationHandlers(db: Pool) {
         }
         const summary = await runReconciliation(db, user.tenantId, stationId, date);
         res.status(201).json({ summary });
+      } catch (err: any) {
+        return errorResponse(res, 400, err.message);
+      }
+    },
+    list: async (req: Request, res: Response) => {
+      try {
+        const user = req.user;
+        if (!user?.tenantId) {
+          return errorResponse(res, 400, 'Missing tenant context');
+        }
+        const { stationId } = req.query as { stationId?: string };
+        const history = await listReconciliations(db, user.tenantId, stationId);
+        res.json({ data: history });
       } catch (err: any) {
         return errorResponse(res, 400, err.message);
       }

--- a/src/routes/reconciliation.route.ts
+++ b/src/routes/reconciliation.route.ts
@@ -10,6 +10,7 @@ export function createReconciliationRouter(db: Pool) {
   const handlers = createReconciliationHandlers(db);
 
   router.post('/', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.create);
+  router.get('/', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.list);
   router.get('/daily-summary', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.getDailySummary);
   router.get('/:stationId', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.get);
 

--- a/src/routes/reports.route.ts
+++ b/src/routes/reports.route.ts
@@ -10,7 +10,10 @@ export function createReportsRouter(db: Pool) {
   const handlers = createReportsHandlers(db);
 
   router.get('/sales/export', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.exportSales);
+  router.get('/sales', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.getSales);
   router.post('/sales', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.exportSalesPost);
+  router.post('/export', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.exportGeneric);
+  router.post('/schedule', authenticateJWT, requireRole([UserRole.Owner, UserRole.Manager]), handlers.scheduleReport);
   router.get('/financial/export', authenticateJWT, requireRole([UserRole.Owner]), handlers.exportFinancial);
 
   return router;

--- a/src/services/reconciliation.service.ts
+++ b/src/services/reconciliation.service.ts
@@ -113,3 +113,20 @@ export async function getReconciliation(
   );
   return res.rows[0];
 }
+
+export async function listReconciliations(
+  db: Pool,
+  tenantId: string,
+  stationId?: string
+) {
+  const params: any[] = [];
+  let query = `SELECT id, station_id, date, total_sales, cash_total, card_total, upi_total, credit_total, finalized
+               FROM ${tenantId}.day_reconciliations`;
+  if (stationId) {
+    query += ' WHERE station_id = $1';
+    params.push(stationId);
+  }
+  query += ' ORDER BY date DESC';
+  const res = await db.query(query, params);
+  return res.rows;
+}


### PR DESCRIPTION
## Summary
- support listing reconciliation history
- add scheduled report storage and generic export handling
- expose sales report via GET, plus export and schedule endpoints
- document new endpoints in OpenAPI
- update schema with `ReportSchedule` table
- sync backend and database docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d41d49c98832085ef888ff2641f94