### PR TITLE
Fix: detailed openapi request schemas

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1584,3 +1584,13 @@ Each entry is tied to a step from the implementation index.
 ### Files
 * `docs/openapi.yaml`
 * `docs/STEP_2_33_COMMAND.md`
+
+## [Fix - 2025-08-04] – Detailed request schemas
+
+### 🟥 Fixes
+* Wired authentication, user and station endpoints to explicit schemas.
+* Added `CreateStationRequest` and `UpdateStationRequest` components.
+
+### Files
+* `docs/openapi.yaml`
+* `docs/STEP_2_34_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -115,3 +115,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 2     | 2.31 | Analytics & GET endpoints | ✅ Done | `src/controllers/analytics.controller.ts`, `src/services/analytics.service.ts`, `src/controllers/alerts.controller.ts`, `src/services/alert.service.ts`, `src/controllers/creditor.controller.ts`, `prisma/schema.prisma`, `docs/openapi.yaml`, `backend_brain.md` | `docs/STEP_2_31_COMMAND.md` |
 | 2     | 2.32 | Parameter naming alignment | ✅ Done | `src/routes/user.route.ts`, `src/routes/station.route.ts`, `docs/openapi.yaml`, `backend_brain.md` | `docs/STEP_2_32_COMMAND.md` |
 | 2     | 2.33 | Reusable response components | ✅ Done | `docs/openapi.yaml` | `docs/STEP_2_33_COMMAND.md` |
+| 2     | 2.34 | OpenAPI request schemas | ✅ Done | `docs/openapi.yaml` | `docs/STEP_2_34_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -598,3 +598,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Added shared `Success` and `Error` response objects under `components.responses`.
+
+### 🛠️ Step 2.34 – OpenAPI request schemas
+**Status:** ✅ Done
+**Files:** `docs/openapi.yaml`, `docs/STEP_2_34_COMMAND.md`
+
+**Overview:**
+* Connected login, refresh, user and station endpoints to detailed schemas.
+* Introduced `CreateStationRequest` and `UpdateStationRequest` components.

--- a/docs/STEP_2_34_COMMAND.md
+++ b/docs/STEP_2_34_COMMAND.md
@@ -1,0 +1,25 @@
+# STEP_2_34_COMMAND.md — OpenAPI Request Schema Detailing
+
+## Project Context Summary
+The backend OpenAPI specification (`docs/openapi.yaml`) lists all endpoints but many request and response bodies still use `type: object` without field definitions. Previous fixes imported schema components from the frontend spec, yet the paths were not wired to those components.
+
+## Steps Already Implemented
+- Generic schemas were replaced with detailed component definitions (STEP_fix_20250731.md).
+- Reusable `Success` and `Error` components were added (STEP_2_33_COMMAND.md).
+
+## What to Build Now
+1. Reference detailed schemas for authentication and user routes.
+2. Add new `CreateStationRequest` and `UpdateStationRequest` schemas.
+3. Update station, login and user endpoints to use these schemas and remove unnecessary request bodies.
+4. Document the change in `CHANGELOG.md`, `PHASE_2_SUMMARY.md` and append a row in `IMPLEMENTATION_INDEX.md`.
+
+## Files To Update
+- `docs/openapi.yaml`
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+
+## Required Documentation Updates
+- Add entry under Fixes in `CHANGELOG.md`.
+- Mark step done in `PHASE_2_SUMMARY.md`.
+- Record this step in `IMPLEMENTATION_INDEX.md`.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,64 +8,92 @@ paths:
   /api/v1/auth/login:
     post:
       summary: User login and JWT issuance
-      responses:
-        '200':
-          $ref: '#/components/responses/Success'
-        default:
-          $ref: '#/components/responses/Error'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Login successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/LoginResponse'
+        default:
+          $ref: '#/components/responses/Error'
   /api/v1/auth/logout:
     post:
       summary: User logout
       responses:
         '200':
-          $ref: '#/components/responses/Success'
+          description: Logout successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      message:
+                        type: string
         default:
           $ref: '#/components/responses/Error'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
   /api/v1/auth/refresh:
     post:
       summary: Refresh JWT token
       responses:
         '200':
-          $ref: '#/components/responses/Success'
+          description: Token refreshed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/LoginResponse'
         default:
           $ref: '#/components/responses/Error'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
   /api/v1/users:
     post:
       summary: Create tenant user
-      responses:
-        '200':
-          $ref: '#/components/responses/Success'
-        default:
-          $ref: '#/components/responses/Error'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: '#/components/schemas/CreateUserRequest'
+      responses:
+        '201':
+          description: User created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        default:
+          $ref: '#/components/responses/Error'
     get:
       summary: List tenant users
       responses:
         '200':
-          $ref: '#/components/responses/Success'
+          description: List of users
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      users:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/User'
         default:
           $ref: '#/components/responses/Error'
   /api/v1/users/{userId}:
@@ -89,17 +117,24 @@ paths:
                     $ref: '#/components/schemas/User'
     put:
       summary: Update tenant user
-      responses:
-        '200':
-          $ref: '#/components/responses/Success'
-        default:
-          $ref: '#/components/responses/Error'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: '#/components/schemas/UpdateUserRequest'
+      responses:
+        '200':
+          description: User updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/User'
+        default:
+          $ref: '#/components/responses/Error'
     delete:
       summary: Delete tenant user
       responses:
@@ -110,50 +145,89 @@ paths:
   /api/v1/users/{userId}/change-password:
     post:
       summary: Change user password
-      responses:
-        '200':
-          $ref: '#/components/responses/Success'
-        default:
-          $ref: '#/components/responses/Error'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: '#/components/schemas/ChangePasswordRequest'
+      responses:
+        '200':
+          description: Password changed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+        default:
+          $ref: '#/components/responses/Error'
   /api/v1/users/{userId}/reset-password:
     post:
       summary: Reset user password
-      responses:
-        '200':
-          $ref: '#/components/responses/Success'
-        default:
-          $ref: '#/components/responses/Error'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: '#/components/schemas/ResetPasswordRequest'
+      responses:
+        '200':
+          description: Password reset
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+        default:
+          $ref: '#/components/responses/Error'
   /api/v1/stations:
     post:
       summary: Create station
-      responses:
-        '200':
-          $ref: '#/components/responses/Success'
-        default:
-          $ref: '#/components/responses/Error'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: '#/components/schemas/CreateStationRequest'
+      responses:
+        '201':
+          description: Station created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+        default:
+          $ref: '#/components/responses/Error'
     get:
       summary: List stations
       responses:
         '200':
-          $ref: '#/components/responses/Success'
+          description: List of stations
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Station'
         default:
           $ref: '#/components/responses/Error'
   /api/v1/stations/{stationId}:
@@ -177,17 +251,24 @@ paths:
                     $ref: '#/components/schemas/Station'
     put:
       summary: Update station
-      responses:
-        '200':
-          $ref: '#/components/responses/Success'
-        default:
-          $ref: '#/components/responses/Error'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: '#/components/schemas/UpdateStationRequest'
+      responses:
+        '200':
+          description: Station updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Station'
+        default:
+          $ref: '#/components/responses/Error'
     delete:
       summary: Delete station
       responses:
@@ -1981,6 +2062,19 @@ components:
         createdAt:
           type: string
           format: date-time
+    CreateStationRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        address:
+          type: string
+    UpdateStationRequest:
+      type: object
+      properties:
+        name:
+          type: string
     SuperAdminSummary:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- reference concrete schemas for auth, user and station requests
- add CreateStationRequest and UpdateStationRequest components
- document OpenAPI schema detailing in CHANGELOG and phase summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d5c7b5f208320b7ac71eaf1b29b7a