### PR TITLE
Fix plan enforcement queries for unified schema

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1685,3 +1685,17 @@ Each entry is tied to a step from the implementation index.
 * `UNIFIED_SCHEMA_MIGRATION.md`, `UNIFIED_DB_SETUP.md`, `SEED_DATA_GUIDE.md`
 * `package.json`
 * `docs/STEP_fix_20250627.md`
+
+## [Fix - 2025-08-16] – Plan Enforcement Tenant Queries
+
+### 🟥 Fixes
+* Plan limit middleware now queries unified tables using `tenant_id`.
+* Services pass tenant IDs instead of schema names.
+
+### Files
+* `src/middleware/planEnforcement.ts`
+* `src/services/station.service.ts`
+* `src/services/pump.service.ts`
+* `src/services/nozzle.service.ts`
+* `src/services/user.service.ts`
+* `docs/STEP_fix_20250816.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -123,3 +123,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-08-14 | Login Query Updates | ✅ Done | `src/controllers/auth.controller.ts`, `src/services/auth.service.ts` | `docs/STEP_fix_20250814.md` |
 | fix | 2025-08-15 | Tenant Service Unified Schema | ✅ Done | `src/services/tenant.service.ts`, `src/controllers/tenant.controller.ts`, `src/validators/tenant.validator.ts`, `tests/utils/testTenant.ts`, `docs/openapi.yaml`, `docs/TENANT_MANAGEMENT_GUIDE.md` | `docs/STEP_2_36_COMMAND.md` |
 | fix | 2025-06-26 | Unified Schema Setup Scripts | ✅ Done | `scripts/*.js`, `UNIFIED_DB_SETUP.md` | `docs/STEP_fix_20250627.md` |
+| fix | 2025-08-16 | Plan Enforcement Tenant Queries | ✅ Done | `src/middleware/planEnforcement.ts`, `src/services/station.service.ts`, `src/services/pump.service.ts`, `src/services/nozzle.service.ts`, `src/services/user.service.ts` | `docs/STEP_fix_20250816.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -643,3 +643,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 * Tenant APIs now operate solely on unified tables via `tenant_id`.
 * Documentation and tests updated accordingly.
 
+
+### 🛠️ Fix 2025-08-16 – Plan Enforcement Tenant Queries
+**Status:** ✅ Done
+**Files:** `src/middleware/planEnforcement.ts`, `src/services/station.service.ts`, `src/services/pump.service.ts`, `src/services/nozzle.service.ts`, `src/services/user.service.ts`, `docs/STEP_fix_20250816.md`
+
+**Overview:**
+* Plan limit checks now query unified tables with `tenant_id` filters.
+* Service layers pass tenant IDs instead of schema names.

--- a/docs/STEP_fix_20250816.md
+++ b/docs/STEP_fix_20250816.md
@@ -1,0 +1,17 @@
+# STEP_fix_20250816.md — Plan Enforcement Tenant Queries
+
+## Project Context Summary
+Plan limit enforcement middleware still referenced tenant schemas for count queries. Now that all data lives in unified public tables, these checks must operate via `tenant_id`.
+
+## Steps Already Implemented
+- Unified schema migration and tenant service fixes up to `STEP_2_36_COMMAND.md`.
+
+## What Was Done Now
+- Updated `fetchPlanId` to look up plans by tenant ID.
+- Replaced schema-based COUNT queries with `tenant_id` filters.
+- Adjusted service calls to pass tenant IDs to plan enforcement helpers.
+
+## Required Documentation Updates
+- Add changelog entry.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_2_SUMMARY.md`.

--- a/src/middleware/planEnforcement.ts
+++ b/src/middleware/planEnforcement.ts
@@ -1,11 +1,11 @@
 import { PoolClient } from 'pg';
 import { getPlanRules } from '../config/planConfig';
 
-// Helper to fetch tenant plan id using schema name
-async function fetchPlanId(db: PoolClient, schemaName: string): Promise<string> {
+// Helper to fetch tenant plan id using tenant id
+async function fetchPlanId(db: PoolClient, tenantId: string): Promise<string> {
   const res = await db.query(
-    'SELECT plan_id FROM public.tenants WHERE schema_name = $1',
-    [schemaName]
+    'SELECT plan_id FROM public.tenants WHERE id = $1',
+    [tenantId]
   );
   return res.rows[0]?.plan_id;
 }
@@ -13,12 +13,15 @@ async function fetchPlanId(db: PoolClient, schemaName: string): Promise<string> 
 // NOTE: The following middleware stubs show the intended logic. Actual routing
 // integration will be implemented in Phase 2.
 
-export async function beforeCreateStation(db: PoolClient, schemaName: string) {
-  const planId = await fetchPlanId(db, schemaName);
+export async function beforeCreateStation(db: PoolClient, tenantId: string) {
+  const planId = await fetchPlanId(db, tenantId);
   const rules = getPlanRules(planId);
 
   // Pseudo count query
-  const countRes = await db.query(`SELECT COUNT(*) FROM ${schemaName}.stations`);
+  const countRes = await db.query(
+    'SELECT COUNT(*) FROM public.stations WHERE tenant_id = $1',
+    [tenantId]
+  );
   if (Number(countRes.rows[0].count) >= rules.maxStations) {
     throw new Error('Plan limit exceeded: stations');
   }
@@ -26,16 +29,16 @@ export async function beforeCreateStation(db: PoolClient, schemaName: string) {
 
 export async function beforeCreatePump(
   db: PoolClient,
-  schemaName: string,
+  tenantId: string,
   stationId: string
 ) {
-  const planId = await fetchPlanId(db, schemaName);
+  const planId = await fetchPlanId(db, tenantId);
   const rules = getPlanRules(planId);
 
   // Pseudo count query per station
   const countRes = await db.query(
-    `SELECT COUNT(*) FROM ${schemaName}.pumps WHERE station_id = $1`,
-    [stationId]
+    'SELECT COUNT(*) FROM public.pumps WHERE tenant_id = $1 AND station_id = $2',
+    [tenantId, stationId]
   );
   if (Number(countRes.rows[0].count) >= rules.maxPumpsPerStation) {
     throw new Error('Plan limit exceeded: pumps per station');
@@ -44,26 +47,29 @@ export async function beforeCreatePump(
 
 export async function beforeCreateNozzle(
   db: PoolClient,
-  schemaName: string,
+  tenantId: string,
   pumpId: string
 ) {
-  const planId = await fetchPlanId(db, schemaName);
+  const planId = await fetchPlanId(db, tenantId);
   const rules = getPlanRules(planId);
 
   const countRes = await db.query(
-    `SELECT COUNT(*) FROM ${schemaName}.nozzles WHERE pump_id = $1`,
-    [pumpId]
+    'SELECT COUNT(*) FROM public.nozzles WHERE tenant_id = $1 AND pump_id = $2',
+    [tenantId, pumpId]
   );
   if (Number(countRes.rows[0].count) >= rules.maxNozzlesPerPump) {
     throw new Error('Plan limit exceeded: nozzles per pump');
   }
 }
 
-export async function beforeCreateUser(db: PoolClient, schemaName: string) {
-  const planId = await fetchPlanId(db, schemaName);
+export async function beforeCreateUser(db: PoolClient, tenantId: string) {
+  const planId = await fetchPlanId(db, tenantId);
   const rules = getPlanRules(planId);
 
-  const countRes = await db.query(`SELECT COUNT(*) FROM ${schemaName}.users`);
+  const countRes = await db.query(
+    'SELECT COUNT(*) FROM public.users WHERE tenant_id = $1',
+    [tenantId]
+  );
   if (Number(countRes.rows[0].count) >= rules.maxEmployees) {
     throw new Error('Plan limit exceeded: users');
   }

--- a/src/services/nozzle.service.ts
+++ b/src/services/nozzle.service.ts
@@ -16,7 +16,7 @@ export async function createNozzle(db: Pool, schemaName: string, pumpId: string,
     
     const tenantId = tenantRes.rows[0].id;
     
-    await beforeCreateNozzle(client, schemaName, pumpId);
+    await beforeCreateNozzle(client, tenantId, pumpId);
     const res = await client.query<{ id: string }>(
       `INSERT INTO ${schemaName}.nozzles (tenant_id, pump_id, nozzle_number, fuel_type) VALUES ($1,$2,$3,$4) RETURNING id`,
       [tenantId, pumpId, nozzleNumber, fuelType]

--- a/src/services/pump.service.ts
+++ b/src/services/pump.service.ts
@@ -16,8 +16,8 @@ export async function createPump(db: Pool, schemaName: string, stationId: string
     
     const tenantId = tenantRes.rows[0].id;
     
-    // Pass schema name to beforeCreatePump (it uses schema for table queries)
-    await beforeCreatePump(client, schemaName, stationId);
+    // Enforce plan limits using tenant id
+    await beforeCreatePump(client, tenantId, stationId);
     
     const res = await client.query<{ id: string }>(
       `INSERT INTO ${schemaName}.pumps (tenant_id, station_id, label, serial_number) VALUES ($1,$2,$3,$4) RETURNING id`,

--- a/src/services/station.service.ts
+++ b/src/services/station.service.ts
@@ -16,8 +16,8 @@ export async function createStation(db: Pool, schemaName: string, name: string, 
     
     const tenantId = tenantRes.rows[0].id;
     
-    // Call beforeCreateStation with the schema name
-    await beforeCreateStation(client, schemaName);
+    // Enforce plan limits using tenant id
+    await beforeCreateStation(client, tenantId);
     
     const res = await client.query<{ id: string }>(
       `INSERT INTO ${schemaName}.stations (tenant_id, name, address) VALUES ($1,$2,$3) RETURNING id`,

--- a/src/services/tenant.service.ts
+++ b/src/services/tenant.service.ts
@@ -105,6 +105,8 @@ export async function createTenant(db: Pool, input: TenantInput): Promise<Tenant
   } finally {
     client.release();
   }
+  // end createTenant
+}
 
 /**
  * List all tenants

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -25,7 +25,7 @@ export async function createUser(
     
     const tenantId = tenantRes.rows[0].id;
     
-    await beforeCreateUser(client, schemaName);
+    await beforeCreateUser(client, tenantId);
     const hash = await bcrypt.hash(password, 10);
     const res = await client.query(
       `INSERT INTO ${schemaName}.users (tenant_id, email, password_hash, name, role) VALUES ($1,$2,$3,$4,$5) RETURNING id`,


### PR DESCRIPTION
## Summary
- query tenant plans by tenant ID
- enforce plan limits against unified tables filtered by tenant_id
- update station, pump, nozzle and user services to pass tenant IDs
- close the createTenant function and document changes
- record changes in documentation

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_685db073dc6c8320a60313a251423bfb