### PR TITLE
Fix auth logging noise

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1729,3 +1729,13 @@ Each entry is tied to a step from the implementation index.
 * `docs/TENANT_MANAGEMENT.md`
 * `docs/BACKEND_HIERARCHY_API.md`
 * `docs/STEP_fix_20250818.md`
+
+## [Fix - 2025-08-19] – Auth Logging Cleanup
+
+### 🟥 Fixes
+* Removed query that listed all admin users during login.
+* Reduced console output to only login attempts and error conditions.
+
+### Files
+* `src/controllers/auth.controller.ts`
+* `docs/STEP_fix_20250819.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -126,3 +126,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-08-16 | Plan Enforcement Tenant Queries | ✅ Done | `src/middleware/planEnforcement.ts`, `src/services/station.service.ts`, `src/services/pump.service.ts`, `src/services/nozzle.service.ts`, `src/services/user.service.ts` | `docs/STEP_fix_20250816.md` |
 | fix | 2025-08-17 | Service Schema Cleanup | ✅ Done | `src/services/*.ts`, `src/controllers/*`, `src/utils/seedHelpers.ts` | `docs/STEP_fix_20250817.md` |
 | fix | 2025-08-18 | Remove schemaName from docs | ✅ Done | `docs/openapi.yaml`, docs updated | `docs/STEP_fix_20250818.md` |
+| fix | 2025-08-19 | Auth Logging Cleanup | ✅ Done | `src/controllers/auth.controller.ts` | `docs/STEP_fix_20250819.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -668,3 +668,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * Purged `schemaName` references from all guides and examples.
 * OpenAPI tenant models only use `planId` and contact fields.
+
+### 🛠️ Fix 2025-08-19 – Auth Logging Cleanup
+**Status:** ✅ Done
+**Files:** `src/controllers/auth.controller.ts`, `docs/STEP_fix_20250819.md`
+
+**Overview:**
+* Removed debug query listing all admin users.
+* Reduced auth controller logs to attempts and errors only.

--- a/docs/STEP_fix_20250819.md
+++ b/docs/STEP_fix_20250819.md
@@ -1,0 +1,16 @@
+# STEP_fix_20250819.md — Auth Logging Cleanup
+
+## Project Context Summary
+The authentication controller still logged extensive debug information, including a query listing all admin users. This created noise in logs after the unified schema migration.
+
+## Steps Already Implemented
+- Unified schema fixes up to `STEP_fix_20250818.md`.
+
+## What Was Done Now
+- Removed the query retrieving all admin users from `auth.controller.ts`.
+- Trimmed console statements to keep only login attempts and error logs.
+
+## Required Documentation Updates
+- Add changelog entry.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_2_SUMMARY.md`.


### PR DESCRIPTION
## Summary
- remove admin list query from auth controller
- log only attempts and errors during login
- document auth logging cleanup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685db85656388320bda3a830e71c4046