### PR TITLE
Clean up deprecated schema_name references

### DIFF
--- a/TENANT_UUID_FIX_SUMMARY.md
+++ b/TENANT_UUID_FIX_SUMMARY.md
@@ -26,7 +26,7 @@ export async function createStation(db: Pool, tenantId: string, name: string) {
 export async function createStation(db: Pool, schemaName: string, name: string) {
   // Get actual tenant UUID from schema name
   const tenantRes = await client.query(
-    'SELECT id FROM public.tenants WHERE schema_name = $1',
+    'SELECT id FROM public.tenants WHERE schema_name = $1', // deprecated lookup
     [schemaName]
   );
   const tenantId = tenantRes.rows[0].id; // ✅ Actual UUID
@@ -71,7 +71,7 @@ const tenantId = req.user?.tenantId || req.headers['x-tenant-id'] as string; // 
 ```sql
 id          UUID PRIMARY KEY     -- This is what tenant_id columns reference
 name        TEXT                 -- Display name
-schema_name TEXT                 -- Schema identifier (production_tenant, etc.)
+schema_name TEXT                 -- Schema identifier (deprecated)
 ```
 
 ### Tenant Schema Tables ({schema}.stations, {schema}.pumps, etc.)

--- a/docs/ANALYTICS_API.md
+++ b/docs/ANALYTICS_API.md
@@ -21,7 +21,7 @@ GET /api/v1/analytics/superadmin
     {
       "id": "uuid",
       "name": "Test Tenant",
-      "schema_name": "test_tenant",
+      // "schema_name": "test_tenant", -- deprecated
       "status": "active",
       "created_at": "2023-01-01T00:00:00Z"
     }
@@ -55,7 +55,7 @@ GET /api/v1/analytics/tenant/:id
   "tenant": {
     "id": "uuid",
     "name": "Test Tenant",
-    "schema_name": "test_tenant",
+    // "schema_name": "test_tenant", -- deprecated
     "status": "active",
     "created_at": "2023-01-01T00:00:00Z",
     "plan_name": "Enterprise Plan"
@@ -120,7 +120,6 @@ function DashboardMetrics() {
             <thead>
               <tr>
                 <th>Name</th>
-                <th>Schema</th>
                 <th>Status</th>
                 <th>Created</th>
               </tr>
@@ -129,7 +128,6 @@ function DashboardMetrics() {
               {metrics?.recentTenants?.map(tenant => (
                 <tr key={tenant.id}>
                   <td>{tenant.name}</td>
-                  <td>{tenant.schema_name}</td>
                   <td>
                     <StatusBadge status={tenant.status} />
                   </td>
@@ -196,10 +194,6 @@ function TenantAnalytics({ tenantId }) {
             <div>
               <p className="text-sm text-gray-500">Status</p>
               <StatusBadge status={analytics?.tenant?.status} />
-            </div>
-            <div>
-              <p className="text-sm text-gray-500">Schema Name</p>
-              <p className="font-medium">{analytics?.tenant?.schema_name}</p>
             </div>
             <div>
               <p className="text-sm text-gray-500">Created</p>

--- a/docs/BACKEND_HIERARCHY_API.md
+++ b/docs/BACKEND_HIERARCHY_API.md
@@ -154,11 +154,11 @@ export async function getTenant(db: Pool, id: string): Promise<any | null> {
   // Get tenant basic info
   const tenant = await getTenantBasicInfo(db, id);
   
-  // Get users ordered by role hierarchy
-  const users = await getUsersByTenant(db, tenant.schema_name);
+  // Get users ordered by role hierarchy (schema_name deprecated)
+  const users = await getUsersByTenant(db, tenant.id);
   
   // Get stations with nested pumps and nozzles
-  const stations = await getStationsWithHierarchy(db, tenant.schema_name);
+  const stations = await getStationsWithHierarchy(db, tenant.id);
   
   return {
     ...tenant,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1788,3 +1788,15 @@ Each entry is tied to a step from the implementation index.
 ### Files
 * `tests/utils/testTenant.ts`
 * `docs/STEP_fix_20250823.md`
+
+## [Fix - 2025-08-24] – Documentation Cleanup for Unified Schema
+
+### 🟥 Fixes
+* Removed or deprecated all `schema_name` references in public docs.
+
+### Files
+* `docs/ANALYTICS_API.md`
+* `docs/SUPERADMIN_FRONTEND_GUIDE.md`
+* `TENANT_UUID_FIX_SUMMARY.md`
+* `docs/BACKEND_HIERARCHY_API.md`
+* `docs/STEP_fix_20250824.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -131,3 +131,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-08-21 | Remove schemaUtils and Update Analytics | ✅ Done | `src/utils/priceUtils.ts`, `src/controllers/adminAnalytics.controller.ts`, `src/controllers/analytics.controller.ts` | `docs/STEP_fix_20250821.md` |
 | fix | 2025-08-22 | Update Setup Database | ✅ Done | `scripts/setup-database.js`, `src/utils/seedHelpers.ts` | `docs/STEP_fix_20250822.md` |
 | fix | 2025-08-23 | Test Helpers Public Schema | ✅ Done | `tests/utils/testTenant.ts` | `docs/STEP_fix_20250823.md` |
+| fix | 2025-08-24 | Docs Cleanup for Unified Schema | ✅ Done | `docs/ANALYTICS_API.md`, `docs/SUPERADMIN_FRONTEND_GUIDE.md` | `docs/STEP_fix_20250824.md` |

--- a/docs/PHASE_1_SUMMARY.md
+++ b/docs/PHASE_1_SUMMARY.md
@@ -48,7 +48,7 @@ Each step includes:
 
 * All tables use UUID PKs
 * Foreign key integrity enforced
-* Unique constraint on tenant `schema_name`
+* Unique constraint on tenant `schema_name` _(deprecated in unified schema)_
 
 **Notes:**
 

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -463,7 +463,7 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Files:** `src/middleware/planEnforcement.ts`
 
 **Overview:**
-* Plan enforcement now resolves tenant plan by `schema_name` instead of UUID, preventing `invalid input syntax for type uuid` errors during station creation.
+* [Deprecated] Initial implementation resolved tenant plan by `schema_name`. Unified schema now uses `tenant_id` lookups.
 
 ### 🛠️ Step 2.21 – CRUD Completion Endpoints
 
@@ -631,7 +631,7 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Files:** `src/controllers/auth.controller.ts`, `src/services/auth.service.ts`, `docs/STEP_fix_20250814.md`
 
 **Overview:**
-* Adjusted login logic to query tenants by UUID instead of `schema_name`.
+* Adjusted login logic to query tenants by UUID instead of the deprecated `schema_name`.
 * Ensures compatibility with the unified schema.
 
 ### 🛠️ Fix 2025-08-15 – Tenant Service Unified Schema
@@ -708,3 +708,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * Test tenant utility inserts rows into `public.tenants` and `public.users`.
 * Fixtures and helpers rely solely on `tenant_id` fields.
+
+### 🛠️ Fix 2025-08-24 – Documentation Cleanup for Unified Schema
+**Status:** ✅ Done
+**Files:** `docs/ANALYTICS_API.md`, `docs/SUPERADMIN_FRONTEND_GUIDE.md`, `TENANT_UUID_FIX_SUMMARY.md`, `docs/BACKEND_HIERARCHY_API.md`, `docs/STEP_fix_20250824.md`
+
+**Overview:**
+* Removed remaining `schema_name` mentions in documentation and marked the field as deprecated.

--- a/docs/STEP_fix_20250824.md
+++ b/docs/STEP_fix_20250824.md
@@ -1,0 +1,16 @@
+# STEP_fix_20250824.md — Documentation Cleanup for Unified Schema
+
+## Project Context Summary
+FuelSync Hub migrated to a unified schema keyed solely by `tenant_id`. Some docs still referenced the old `schema_name` field which no longer exists.
+
+## Steps Already Implemented
+- Unified schema migration and previous documentation fixes up to `STEP_fix_20250823.md`.
+
+## What Was Done Now
+- Removed or marked deprecated `schema_name` examples in developer guides.
+- Added notes about the unified schema refactor in summary and changelog files.
+
+## Required Documentation Updates
+- Add changelog entry.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_2_SUMMARY.md`.

--- a/docs/SUPERADMIN_FRONTEND_GUIDE.md
+++ b/docs/SUPERADMIN_FRONTEND_GUIDE.md
@@ -226,7 +226,6 @@ function DashboardMetrics() {
             <thead>
               <tr>
                 <th>Name</th>
-                <th>Schema</th>
                 <th>Status</th>
                 <th>Created</th>
               </tr>
@@ -235,7 +234,6 @@ function DashboardMetrics() {
               {metrics?.recentTenants?.map(tenant => (
                 <tr key={tenant.id}>
                   <td>{tenant.name}</td>
-                  <td>{tenant.schema_name}</td>
                   <td>
                     <StatusBadge status={tenant.status} />
                   </td>


### PR DESCRIPTION
## Summary
- remove schema_name from Analytics and SuperAdmin guides
- mark schema_name as deprecated in UUID fix doc and hierarchy API
- note unified-schema changes in phase summaries and changelog
- track step in implementation index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dc24395c083209658798e77c0bf9f