### PR TITLE
Move node typings to dev dependencies

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1800,3 +1800,12 @@ Each entry is tied to a step from the implementation index.
 * `TENANT_UUID_FIX_SUMMARY.md`
 * `docs/BACKEND_HIERARCHY_API.md`
 * `docs/STEP_fix_20250824.md`
+
+## [Fix - 2025-08-25] – Node typings moved back to dev deps
+
+### 🟥 Fixes
+* Moved `@types/node` from regular dependencies to `devDependencies`.
+
+### Files
+* `package.json`
+* `docs/STEP_fix_20250825.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -132,3 +132,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-08-22 | Update Setup Database | ✅ Done | `scripts/setup-database.js`, `src/utils/seedHelpers.ts` | `docs/STEP_fix_20250822.md` |
 | fix | 2025-08-23 | Test Helpers Public Schema | ✅ Done | `tests/utils/testTenant.ts` | `docs/STEP_fix_20250823.md` |
 | fix | 2025-08-24 | Docs Cleanup for Unified Schema | ✅ Done | `docs/ANALYTICS_API.md`, `docs/SUPERADMIN_FRONTEND_GUIDE.md` | `docs/STEP_fix_20250824.md` |
+| fix | 2025-08-25 | Node typings dev dependency | ✅ Done | `package.json` | `docs/STEP_fix_20250825.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -715,3 +715,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Removed remaining `schema_name` mentions in documentation and marked the field as deprecated.
+
+### 🛠️ Fix 2025-08-25 – Node typings dev dependency
+**Status:** ✅ Done
+**Files:** `package.json`, `docs/STEP_fix_20250825.md`
+
+**Overview:**
+* Moved `@types/node` back to `devDependencies` now that the build installs dev packages.

--- a/docs/STEP_fix_20250825.md
+++ b/docs/STEP_fix_20250825.md
@@ -1,0 +1,16 @@
+# STEP_fix_20250825.md — Node typings moved back to dev deps
+
+## Project Context Summary
+Earlier Azure builds required `@types/node` in regular dependencies. The project now installs dev dependencies during build, so the typings can live under `devDependencies`.
+
+## Steps Already Implemented
+- Documentation cleanup up to `STEP_fix_20250824.md`.
+
+## What Was Done Now
+- Moved `@types/node` from `dependencies` to `devDependencies` in `package.json`.
+- Reinstalled packages and ensured `npm run build` invokes `tsc` without missing `node` typings.
+
+## Required Documentation Updates
+- Add changelog entry.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_2_SUMMARY.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@types/cors": "^2.8.13",
         "@types/express": "^4.17.17",
         "@types/jsonwebtoken": "^9.0.2",
-        "@types/node": "^20.2.5",
         "@types/pg": "^8.10.1",
         "@types/swagger-ui-express": "^4.1.8",
         "axios": "^1.6.0",
@@ -30,6 +29,7 @@
         "typescript": "^5.0.4"
       },
       "devDependencies": {
+        "@types/node": "^20.2.5",
         "prisma": "^6.10.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
     "@types/jsonwebtoken": "^9.0.2",
-    "@types/node": "^20.2.5",
     "@types/pg": "^8.10.1",
     "@types/swagger-ui-express": "^4.1.8",
     "axios": "^1.6.0",
@@ -47,6 +46,7 @@
     "typescript": "^5.0.4"
   },
   "devDependencies": {
-    "prisma": "^6.10.1"
+    "prisma": "^6.10.1",
+    "@types/node": "^20.2.5"
   }
 }


### PR DESCRIPTION
## Summary
- move `@types/node` from dependencies to devDependencies
- document change in step files and logs

## Testing
- `npm install`
- `npm run build` *(fails: TS errors in services)*

------
https://chatgpt.com/codex/tasks/task_e_685dc3afcd9483209f8bc1d6fdf6f5f0