### PR TITLE
Add master unified schema migration

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1809,3 +1809,21 @@ Each entry is tied to a step from the implementation index.
 ### Files
 * `package.json`
 * `docs/STEP_fix_20250825.md`
+
+## [Fix - 2025-08-26] – Unified Schema Cleanup
+
+### 🟥 Fixes
+* Consolidated migrations into `005_master_unified_schema.sql`.
+* Removed deprecated `schemaName` usage across the codebase.
+* Updated OpenAPI spec to match unified schema.
+
+### Files
+* `migrations/schema/005_master_unified_schema.sql`
+* `scripts/apply-unified-schema.js`
+* `src/app.ts`
+* `src/controllers/admin.controller.ts`
+* `src/controllers/analytics.controller.ts`
+* `src/middlewares/*.ts`
+* `src/types/auth.d.ts`
+* `frontend/docs/openapi-v1.yaml`
+* `docs/STEP_fix_20250826.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -133,3 +133,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-08-23 | Test Helpers Public Schema | ✅ Done | `tests/utils/testTenant.ts` | `docs/STEP_fix_20250823.md` |
 | fix | 2025-08-24 | Docs Cleanup for Unified Schema | ✅ Done | `docs/ANALYTICS_API.md`, `docs/SUPERADMIN_FRONTEND_GUIDE.md` | `docs/STEP_fix_20250824.md` |
 | fix | 2025-08-25 | Node typings dev dependency | ✅ Done | `package.json` | `docs/STEP_fix_20250825.md` |
+| fix | 2025-08-26 | Unified Schema Cleanup | ✅ Done | `src/app.ts`, `src/controllers/admin.controller.ts`, `src/controllers/analytics.controller.ts`, `src/middlewares/*`, `src/types/auth.d.ts`, `migrations/schema/005_master_unified_schema.sql`, `scripts/apply-unified-schema.js`, `frontend/docs/openapi-v1.yaml` | `docs/STEP_fix_20250826.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -722,3 +722,12 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Moved `@types/node` back to `devDependencies` now that the build installs dev packages.
+
+### 🛠️ Fix 2025-08-26 – Unified Schema Cleanup
+**Status:** ✅ Done
+**Files:** `src/app.ts`, `src/controllers/admin.controller.ts`, `src/controllers/analytics.controller.ts`, `src/middlewares/*`, `src/types/auth.d.ts`, `migrations/schema/005_master_unified_schema.sql`, `scripts/apply-unified-schema.js`, `frontend/docs/openapi-v1.yaml`, `docs/STEP_fix_20250826.md`
+
+**Overview:**
+* Removed deprecated `schemaName` logic from codebase.
+* Single migration file simplifies new environment setup.
+* API definitions updated for tenant-based schema.

--- a/docs/STEP_fix_20250826.md
+++ b/docs/STEP_fix_20250826.md
@@ -1,0 +1,19 @@
+# STEP_fix_20250826.md — Unified Schema Cleanup
+
+## Project Context Summary
+FuelSync Hub uses a unified database schema keyed by `tenant_id`. Older files still referenced the former `schemaName` field and migrations were scattered across multiple SQL files.
+
+## Steps Already Implemented
+- Unified schema defined in `004_complete_unified_schema.sql` and Prisma setup.
+- Documentation updates through `STEP_fix_20250825.md`.
+
+## What Was Done Now
+- Consolidated migrations into a single `005_master_unified_schema.sql` file and updated the apply script.
+- Removed `schemaName` usage from middleware, controllers and type definitions.
+- Simplified the `/schemas` debug endpoint to list public tables only.
+- Updated the OpenAPI spec to drop `schemaName` fields.
+
+## Required Documentation Updates
+- Add changelog entry.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_2_SUMMARY.md`.

--- a/frontend/docs/openapi-v1.yaml
+++ b/frontend/docs/openapi-v1.yaml
@@ -2096,8 +2096,6 @@ components:
           type: string
         name:
           type: string
-        schemaName:
-          type: string
         planId:
           type: string
         planName:
@@ -2117,8 +2115,6 @@ components:
       required: [name, planId]
       properties:
         name:
-          type: string
-        schemaName:
           type: string
         planId:
           type: string

--- a/migrations/schema/005_master_unified_schema.sql
+++ b/migrations/schema/005_master_unified_schema.sql
@@ -1,0 +1,314 @@
+-- Migration: 005_master_unified_schema
+-- Description: Master unified schema for fresh setups
+-- Version: 1.0.0
+-- Dependencies: None
+
+BEGIN;
+
+-- Ensure core tables exist with proper structure
+CREATE TABLE IF NOT EXISTS public.plans (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  max_stations INTEGER NOT NULL DEFAULT 5,
+  max_pumps_per_station INTEGER NOT NULL DEFAULT 10,
+  max_nozzles_per_pump INTEGER NOT NULL DEFAULT 4,
+  price_monthly DECIMAL(10,2) NOT NULL DEFAULT 0,
+  price_yearly DECIMAL(10,2) NOT NULL DEFAULT 0,
+  features JSONB NOT NULL DEFAULT '[]',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.tenants (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  plan_id UUID REFERENCES public.plans(id),
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'suspended', 'cancelled')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at TIMESTAMPTZ NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.admin_users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email TEXT NOT NULL UNIQUE,
+  password_hash TEXT NOT NULL,
+  name TEXT,
+  role TEXT NOT NULL DEFAULT 'superadmin',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.admin_activity_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  admin_user_id UUID REFERENCES public.admin_users(id) ON DELETE CASCADE,
+  action TEXT NOT NULL,
+  target_type TEXT,
+  target_id UUID,
+  details JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Tenant-specific tables with tenant_id
+CREATE TABLE IF NOT EXISTS public.users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  email TEXT NOT NULL,
+  password_hash TEXT NOT NULL,
+  name TEXT NOT NULL,
+  role TEXT NOT NULL CHECK (role IN ('owner','manager','attendant')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, email)
+);
+
+CREATE TABLE IF NOT EXISTS public.stations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  address TEXT,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','inactive','maintenance')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS public.pumps (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  station_id UUID NOT NULL REFERENCES public.stations(id) ON DELETE CASCADE,
+  label TEXT NOT NULL,
+  serial_number VARCHAR(100),
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','inactive','maintenance')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, station_id, label)
+);
+
+CREATE TABLE IF NOT EXISTS public.nozzles (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  pump_id UUID NOT NULL REFERENCES public.pumps(id) ON DELETE CASCADE,
+  nozzle_number INTEGER NOT NULL,
+  fuel_type TEXT NOT NULL CHECK (fuel_type IN ('petrol','diesel','premium')),
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','inactive','maintenance')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, pump_id, nozzle_number)
+);
+
+CREATE TABLE IF NOT EXISTS public.fuel_prices (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  station_id UUID NOT NULL REFERENCES public.stations(id) ON DELETE CASCADE,
+  fuel_type TEXT NOT NULL CHECK (fuel_type IN ('petrol','diesel','premium')),
+  price DECIMAL(10,2) NOT NULL CHECK (price > 0),
+  cost_price DECIMAL(10,2) DEFAULT 0,
+  valid_from TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  effective_to TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.creditors (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  station_id UUID REFERENCES public.stations(id) ON DELETE CASCADE,
+  party_name TEXT NOT NULL,
+  contact_number TEXT,
+  address TEXT,
+  credit_limit DECIMAL(10,2) DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','inactive')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.sales (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  nozzle_id UUID NOT NULL REFERENCES public.nozzles(id) ON DELETE CASCADE,
+  reading_id UUID REFERENCES public.nozzle_readings(id),
+  station_id UUID NOT NULL REFERENCES public.stations(id) ON DELETE CASCADE,
+  volume DECIMAL(10,3) NOT NULL CHECK (volume >= 0),
+  fuel_type TEXT NOT NULL CHECK (fuel_type IN ('petrol','diesel','premium')),
+  fuel_price DECIMAL(10,2) NOT NULL,
+  cost_price DECIMAL(10,2) DEFAULT 0,
+  amount DECIMAL(10,2) NOT NULL,
+  profit DECIMAL(10,2) DEFAULT 0,
+  payment_method TEXT NOT NULL CHECK (payment_method IN ('cash','card','upi','credit')),
+  creditor_id UUID REFERENCES public.creditors(id),
+  created_by UUID REFERENCES public.users(id),
+  status TEXT NOT NULL DEFAULT 'posted' CHECK (status IN ('draft','posted')),
+  recorded_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.user_stations (
+  user_id UUID REFERENCES public.users(id) ON DELETE CASCADE,
+  station_id UUID REFERENCES public.stations(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, station_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.tenant_settings (
+  tenant_id UUID PRIMARY KEY REFERENCES public.tenants(id) ON DELETE CASCADE,
+  receipt_template TEXT,
+  fuel_rounding TEXT,
+  branding_logo_url TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.fuel_inventory (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  station_id UUID NOT NULL REFERENCES public.stations(id) ON DELETE CASCADE,
+  fuel_type TEXT NOT NULL CHECK (fuel_type IN ('petrol','diesel','premium')),
+  current_stock DECIMAL(10,3) NOT NULL DEFAULT 0,
+  minimum_level DECIMAL(10,3) NOT NULL DEFAULT 1000,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_updated TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.alerts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  station_id UUID REFERENCES public.stations(id) ON DELETE CASCADE,
+  alert_type TEXT NOT NULL,
+  message TEXT NOT NULL,
+  severity TEXT NOT NULL DEFAULT 'info',
+  is_read BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.fuel_deliveries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  station_id UUID NOT NULL REFERENCES public.stations(id) ON DELETE CASCADE,
+  fuel_type TEXT NOT NULL CHECK (fuel_type IN ('petrol','diesel','premium')),
+  volume DECIMAL(10,3) NOT NULL CHECK (volume > 0),
+  delivered_by TEXT,
+  delivery_date DATE NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.nozzle_readings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  nozzle_id UUID NOT NULL REFERENCES public.nozzles(id) ON DELETE CASCADE,
+  reading DECIMAL(10,2) NOT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL,
+  payment_method TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.credit_payments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  creditor_id UUID NOT NULL REFERENCES public.creditors(id) ON DELETE CASCADE,
+  amount DECIMAL(10,2) NOT NULL CHECK (amount >= 0),
+  payment_method TEXT CHECK (payment_method IN ('cash','card','upi','credit')),
+  reference_number TEXT,
+  notes TEXT,
+  received_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.day_reconciliations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  station_id UUID NOT NULL REFERENCES public.stations(id) ON DELETE CASCADE,
+  date DATE NOT NULL,
+  total_sales DECIMAL(10,2) DEFAULT 0,
+  cash_total DECIMAL(10,2) DEFAULT 0,
+  card_total DECIMAL(10,2) DEFAULT 0,
+  upi_total DECIMAL(10,2) DEFAULT 0,
+  credit_total DECIMAL(10,2) DEFAULT 0,
+  finalized BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, station_id, date)
+);
+
+CREATE TABLE IF NOT EXISTS public.report_schedules (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  station_id UUID REFERENCES public.stations(id) ON DELETE CASCADE,
+  type TEXT NOT NULL,
+  frequency TEXT NOT NULL,
+  next_run TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.audit_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  action TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id UUID NOT NULL,
+  details JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.user_activity_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID REFERENCES public.tenants(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES public.users(id) ON DELETE CASCADE,
+  ip_address TEXT,
+  user_agent TEXT,
+  event TEXT,
+  recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.validation_issues (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID REFERENCES public.tenants(id) ON DELETE CASCADE,
+  entity_type TEXT NOT NULL,
+  entity_id UUID NOT NULL,
+  message TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Create indexes for performance
+CREATE INDEX IF NOT EXISTS idx_tenants_status_deleted_at ON public.tenants(status, deleted_at);
+CREATE INDEX IF NOT EXISTS idx_users_tenant ON public.users(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_stations_tenant ON public.stations(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_pumps_tenant ON public.pumps(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_pumps_station_id ON public.pumps(station_id);
+CREATE INDEX IF NOT EXISTS idx_nozzles_tenant ON public.nozzles(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_fuel_prices_tenant ON public.fuel_prices(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_fuel_prices_station_id ON public.fuel_prices(station_id);
+CREATE INDEX IF NOT EXISTS idx_creditors_tenant ON public.creditors(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_sales_tenant ON public.sales(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_sales_nozzle_id ON public.sales(nozzle_id);
+CREATE INDEX IF NOT EXISTS idx_sales_created_at ON public.sales(created_at);
+CREATE INDEX IF NOT EXISTS idx_user_stations_user ON public.user_stations(user_id);
+CREATE INDEX IF NOT EXISTS idx_fuel_inventory_tenant ON public.fuel_inventory(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_alerts_tenant ON public.alerts(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_fuel_deliveries_tenant ON public.fuel_deliveries(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_nozzle_readings_tenant ON public.nozzle_readings(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_credit_payments_tenant ON public.credit_payments(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_credit_payments_creditor_id ON public.credit_payments(creditor_id);
+CREATE INDEX IF NOT EXISTS idx_day_reconciliations_tenant ON public.day_reconciliations(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_report_schedules_tenant ON public.report_schedules(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_tenant ON public.audit_logs(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_user_activity_logs_tenant ON public.user_activity_logs(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_validation_issues_tenant ON public.validation_issues(tenant_id);
+
+-- Record migration
+INSERT INTO public.schema_migrations (version, description)
+VALUES ('005', 'Master unified schema for fresh setups')
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/scripts/apply-unified-schema.js
+++ b/scripts/apply-unified-schema.js
@@ -30,7 +30,7 @@ async function applyMigration() {
     console.log('✅ Ensured schema_migrations table exists');
     
     // Read the migration file
-    const migrationPath = path.join(__dirname, '../migrations/schema/004_complete_unified_schema.sql');
+    const migrationPath = path.join(__dirname, '../migrations/schema/005_master_unified_schema.sql');
     const migrationSql = fs.readFileSync(migrationPath, 'utf8');
     
     // Execute the migration
@@ -41,7 +41,7 @@ async function applyMigration() {
     // Record the migration
     await pool.query(`
       INSERT INTO public.schema_migrations (version, description)
-      VALUES ('004', 'Complete unified schema migration aligned with db_brain.md')
+      VALUES ('005', 'Master unified schema for fresh setups')
       ON CONFLICT (version) DO NOTHING;
     `);
     

--- a/src/app.ts
+++ b/src/app.ts
@@ -117,7 +117,7 @@ export function createApp() {
     }
   });
   
-  // Debug schemas and tables endpoint with reset option
+  // Debug tables endpoint with reset option
   app.get('/schemas', async (req, res) => {
     try {
       const reset = req.query.reset;
@@ -134,15 +134,8 @@ export function createApp() {
         return successResponse(res, { status: 'Database reset complete' });
       }
       
-      const schemas = await pool.query("SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('information_schema', 'pg_catalog', 'pg_toast')");
-      
-      const tablesInfo: Record<string, string[]> = {};
-      for (const schema of schemas.rows) {
-        const tables = await pool.query("SELECT table_name FROM information_schema.tables WHERE table_schema = $1", [schema.schema_name]);
-        tablesInfo[schema.schema_name] = tables.rows.map(t => t.table_name);
-      }
-      
-      successResponse(res, { schemas: schemas.rows, tables: tablesInfo });
+      const tablesResult = await pool.query("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'");
+      successResponse(res, { tables: tablesResult.rows.map(t => t.table_name) });
     } catch (err: any) {
       errorResponse(res, 500, err.message);
     }

--- a/src/controllers/admin.controller.ts
+++ b/src/controllers/admin.controller.ts
@@ -11,7 +11,7 @@ export function createAdminApiHandlers(db: Pool) {
     // Tenant Management
     createTenant: async (req: Request, res: Response) => {
       try {
-        const { name, planId, schemaName, ownerName, ownerEmail, ownerPassword } = req.body;
+        const { name, planId, ownerName, ownerEmail, ownerPassword } = req.body;
         
         if (!name || !planId) {
           return errorResponse(res, 400, 'Name and planId are required');
@@ -20,7 +20,6 @@ export function createAdminApiHandlers(db: Pool) {
         const tenant = await tenantService.createTenant(db, {
           name,
           planId,
-          schemaName,
           ownerName,
           ownerEmail,
           ownerPassword

--- a/src/controllers/analytics.controller.ts
+++ b/src/controllers/analytics.controller.ts
@@ -102,7 +102,7 @@ export function createAnalyticsHandlers(db: Pool) {
         
         // Get tenant details
         const tenantResult = await db.query(`
-          SELECT t.id, t.name, t.schema_name, t.status, t.created_at, p.name as plan_name
+          SELECT t.id, t.name, t.status, t.created_at, p.name as plan_name
           FROM public.tenants t
           JOIN public.plans p ON t.plan_id = p.id
           WHERE t.id = $1

--- a/src/middlewares/debugRequest.ts
+++ b/src/middlewares/debugRequest.ts
@@ -9,7 +9,6 @@ export function debugRequest(req: Request, _res: Response, next: NextFunction) {
   console.log('Method:', req.method);
   console.log('Headers:', JSON.stringify(req.headers, null, 2));
   console.log('Tenant ID:', req.headers['x-tenant-id']);
-  console.log('Schema Name:', (req as any).schemaName);
   console.log('==== END DEBUG ====');
   next();
 }

--- a/src/middlewares/defaultTenant.ts
+++ b/src/middlewares/defaultTenant.ts
@@ -8,12 +8,6 @@ export function defaultTenant(req: Request, _res: Response, next: NextFunction) 
   if (req.path.startsWith('/api/v1/admin') || req.path.startsWith('/api/v1/auth')) {
     return next();
   }
-  
-  // If tenant ID not set, default to production_tenant
-  if (!(req as any).schemaName) {
-    console.log('Setting default tenant: production_tenant');
-    (req as any).schemaName = 'production_tenant';
-  }
-  
+
   next();
 }

--- a/src/middlewares/setTenantContext.ts
+++ b/src/middlewares/setTenantContext.ts
@@ -17,10 +17,7 @@ export function setTenantContext(req: Request, res: Response, next: NextFunction
     return next();
   }
   
-  const user = req.user as AuthPayload;
-  
-  // Unified schema uses public namespace; keep property for backward compatibility
-  (req as any).schemaName = 'public';
+  const _user = req.user as AuthPayload;
   
   next();
 }

--- a/src/types/auth.d.ts
+++ b/src/types/auth.d.ts
@@ -10,7 +10,6 @@ declare global {
   namespace Express {
     interface Request {
       user?: AuthPayload;
-      schemaName?: string;
     }
   }
 }


### PR DESCRIPTION
## Summary
- create `005_master_unified_schema.sql` as the single migration
- update apply script to use the new master migration
- remove deprecated `schemaName` references from code
- simplify `/schemas` debug route
- drop `schemaName` from OpenAPI spec
- document unified schema cleanup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dc4f053048320a141e74f65a03775