### PR TITLE
Fix SQL string literals causing build failure

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1827,3 +1827,14 @@ Each entry is tied to a step from the implementation index.
 * `src/types/auth.d.ts`
 * `frontend/docs/openapi-v1.yaml`
 * `docs/STEP_fix_20250826.md`
+
+## [Fix - 2025-08-27] – SQL String Literal Fixes
+
+### 🟥 Fixes
+* Replaced invalid multi-line single-quoted SQL strings with template strings.
+* Build now succeeds without syntax errors.
+
+### Files
+* `src/services/creditor.service.ts`
+* `src/services/fuelPrice.service.ts`
+* `docs/STEP_fix_20250827.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -134,3 +134,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-08-24 | Docs Cleanup for Unified Schema | ✅ Done | `docs/ANALYTICS_API.md`, `docs/SUPERADMIN_FRONTEND_GUIDE.md` | `docs/STEP_fix_20250824.md` |
 | fix | 2025-08-25 | Node typings dev dependency | ✅ Done | `package.json` | `docs/STEP_fix_20250825.md` |
 | fix | 2025-08-26 | Unified Schema Cleanup | ✅ Done | `src/app.ts`, `src/controllers/admin.controller.ts`, `src/controllers/analytics.controller.ts`, `src/middlewares/*`, `src/types/auth.d.ts`, `migrations/schema/005_master_unified_schema.sql`, `scripts/apply-unified-schema.js`, `frontend/docs/openapi-v1.yaml` | `docs/STEP_fix_20250826.md` |
+| fix | 2025-08-27 | SQL String Literal Fixes | ✅ Done | `src/services/creditor.service.ts`, `src/services/fuelPrice.service.ts` | `docs/STEP_fix_20250827.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -731,3 +731,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 * Removed deprecated `schemaName` logic from codebase.
 * Single migration file simplifies new environment setup.
 * API definitions updated for tenant-based schema.
+
+### 🛠️ Fix 2025-08-27 – SQL String Literal Fixes
+**Status:** ✅ Done
+**Files:** `src/services/creditor.service.ts`, `src/services/fuelPrice.service.ts`, `docs/STEP_fix_20250827.md`
+
+**Overview:**
+* Multi-line SQL queries now use template strings instead of single quotes.
+* `npm run build` compiles without errors.

--- a/docs/STEP_fix_20250827.md
+++ b/docs/STEP_fix_20250827.md
@@ -1,0 +1,18 @@
+# STEP_fix_20250827.md — SQL String Literal Fixes
+
+## Project Context Summary
+The TypeScript build failed because some service queries used single-quoted strings across multiple lines.
+JavaScript does not allow newline characters inside single-quoted strings, causing `tsc` errors.
+
+## Steps Already Implemented
+- Unified schema cleanup up to `STEP_fix_20250826.md`.
+
+## What Was Done Now
+- Replaced multi-line single-quoted SQL queries with template strings in
+  `src/services/creditor.service.ts` and `src/services/fuelPrice.service.ts`.
+- Verified compilation succeeds with `npm run build`.
+
+## Required Documentation Updates
+- Add changelog entry.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_2_SUMMARY.md`.

--- a/src/services/creditor.service.ts
+++ b/src/services/creditor.service.ts
@@ -4,8 +4,8 @@ import { isDateFinalized } from './reconciliation.service';
 
 export async function createCreditor(db: Pool, tenantId: string, input: CreditorInput): Promise<string> {
   const res = await db.query<{ id: string }>(
-    'INSERT INTO public.creditors (tenant_id, party_name, contact_number, address, credit_limit)
-     VALUES ($1,$2,$3,$4,$5) RETURNING id',
+    `INSERT INTO public.creditors (tenant_id, party_name, contact_number, address, credit_limit)
+     VALUES ($1,$2,$3,$4,$5) RETURNING id`,
     [tenantId, input.partyName, input.contactNumber || null, input.address || null, input.creditLimit || 0]
   );
   return res.rows[0].id;
@@ -70,8 +70,8 @@ export async function createCreditPayment(
       throw new Error('Invalid creditor');
     }
     const res = await client.query<{ id: string }>(
-      'INSERT INTO public.credit_payments (tenant_id, creditor_id, amount, payment_method, reference_number, received_by, received_at)
-       VALUES ($1,$2,$3,$4,$5,$6,NOW()) RETURNING id',
+      `INSERT INTO public.credit_payments (tenant_id, creditor_id, amount, payment_method, reference_number, received_by, received_at)
+       VALUES ($1,$2,$3,$4,$5,$6,NOW()) RETURNING id`,
       [tenantId, input.creditorId, input.amount, input.paymentMethod, input.referenceNumber || null, userId]
     );
     await decrementCreditorBalance(client, tenantId, input.creditorId, input.amount);

--- a/src/services/fuelPrice.service.ts
+++ b/src/services/fuelPrice.service.ts
@@ -6,8 +6,8 @@ export async function createFuelPrice(db: Pool, tenantId: string, input: FuelPri
   try {
     await client.query('BEGIN');
     const res = await client.query<{ id: string }>(
-      'INSERT INTO public.fuel_prices (tenant_id, station_id, fuel_type, price, valid_from)
-       VALUES ($1,$2,$3,$4,$5) RETURNING id',
+      `INSERT INTO public.fuel_prices (tenant_id, station_id, fuel_type, price, valid_from)
+       VALUES ($1,$2,$3,$4,$5) RETURNING id`,
       [tenantId, input.stationId, input.fuelType, input.price, input.effectiveFrom || new Date()]
     );
     await client.query('COMMIT');


### PR DESCRIPTION
## Summary
- fix SQL queries to use template strings in services
- document build fix for SQL string literals

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dc76c9cd8832095e1e0497ff81ed0