### PR TITLE
Add admin login route

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1871,3 +1871,17 @@ Each entry is tied to a step from the implementation index.
 * `src/services/inventory.service.ts`
 * `src/services/fuelInventory.service.ts`
 * `docs/STEP_fix_20250829.md`
+
+## [Fix - 2025-08-30] – Admin Login Route
+
+### 🟥 Fixes
+* Introduced dedicated SuperAdmin login endpoint `/api/v1/admin/auth/login`.
+* Added explicit service and controller logic to reject non-admin credentials.
+
+### Files
+* `src/routes/adminAuth.route.ts`
+* `src/controllers/auth.controller.ts`
+* `src/services/auth.service.ts`
+* `src/app.ts`
+* `docs/openapi.yaml`
+* `docs/STEP_fix_20250830.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -137,3 +137,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-08-27 | SQL String Literal Fixes | ✅ Done | `src/services/creditor.service.ts`, `src/services/fuelPrice.service.ts` | `docs/STEP_fix_20250827.md` |
 | fix | 2025-08-28 | Backend UUID Generation | ✅ Done | `src/services/tenant.service.ts`, `src/services/admin.service.ts`, `src/services/plan.service.ts` | `docs/STEP_fix_20250828.md` |
 | fix | 2025-08-29 | Comprehensive UUID Insertion | ✅ Done | `src/services/*` | `docs/STEP_fix_20250829.md` |
+| fix | 2025-08-30 | Admin login route | ✅ Done | `src/routes/adminAuth.route.ts`, `src/controllers/auth.controller.ts`, `src/services/auth.service.ts`, `src/app.ts`, `docs/openapi.yaml` | `docs/STEP_fix_20250830.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -755,3 +755,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * Remaining service-layer inserts now supply UUIDs explicitly.
 * Prevents `null value in column "id"` errors across all tables on Azure.
+
+### 🛠️ Fix 2025-08-30 – Admin login route
+**Status:** ✅ Done
+**Files:** `src/routes/adminAuth.route.ts`, `src/controllers/auth.controller.ts`, `src/services/auth.service.ts`, `src/app.ts`, `docs/openapi.yaml`, `docs/STEP_fix_20250830.md`
+
+**Overview:**
+* Added dedicated `/api/v1/admin/auth/login` endpoint for SuperAdmin authentication.
+* Ensures admin logins fail fast when credentials do not match an admin user.

--- a/docs/STEP_fix_20250830.md
+++ b/docs/STEP_fix_20250830.md
@@ -1,0 +1,17 @@
+# STEP_fix_20250830.md — Admin Login Route
+
+## Project Context Summary
+Frontend updates introduced a dedicated SuperAdmin login screen that sends credentials to `/api/v1/admin/auth/login`. The backend only exposed `/api/v1/auth/login`, causing 404 errors for the admin route.
+
+## Steps Already Implemented
+Backend authentication flow with tenant-aware login and SuperAdmin detection up to `STEP_fix_20250829.md`.
+
+## What Was Done Now
+- Added `loginSuperAdmin` service method and `adminLogin` controller handler.
+- Created `adminAuth.route.ts` and mounted at `/api/v1/admin/auth` in `app.ts`.
+- Extended OpenAPI spec with `/api/v1/admin/auth/login` path.
+
+## Required Documentation Updates
+- Add changelog entry.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_2_SUMMARY.md`.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -26,6 +26,27 @@ paths:
                     $ref: '#/components/schemas/LoginResponse'
         default:
           $ref: '#/components/responses/Error'
+  /api/v1/admin/auth/login:
+    post:
+      summary: SuperAdmin login
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Login successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/LoginResponse'
+        default:
+          $ref: '#/components/responses/Error'
   /api/v1/auth/logout:
     post:
       summary: User logout

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import pool from './utils/db';
 import { createAuthRouter } from './routes/auth.route';
+import { createAdminAuthRouter } from './routes/adminAuth.route';
 import { createAdminApiRouter } from './routes/adminApi.router';
 import { createUserRouter } from './routes/user.route';
 import { createStationRouter } from './routes/station.route';
@@ -154,6 +155,7 @@ export function createApp() {
   const API_PREFIX = '/api/v1';
 
   app.use(`${API_PREFIX}/auth`, createAuthRouter(pool));
+  app.use(`${API_PREFIX}/admin/auth`, createAdminAuthRouter(pool));
   app.use(`${API_PREFIX}/admin`, createAdminApiRouter(pool));
   app.use(`${API_PREFIX}/users`, createUserRouter(pool));
   app.use(`${API_PREFIX}/stations`, createStationRouter(pool));

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import { Pool } from 'pg';
-import { login } from '../services/auth.service';
+import { login, loginSuperAdmin } from '../services/auth.service';
 import { errorResponse } from '../utils/errorResponse';
 import { successResponse } from '../utils/successResponse';
 
@@ -81,6 +81,23 @@ export function createAuthController(db: Pool) {
         return successResponse(res, result);
       } catch (error: any) {
         console.error(`[AUTH] Login error:`, error);
+        return errorResponse(res, 500, `Login error: ${error?.message || 'Unknown error'}`);
+      }
+    },
+    adminLogin: async (req: Request, res: Response) => {
+      const { email, password } = req.body as { email: string; password: string };
+      console.log(`[AUTH] Admin login attempt for email: ${email}`);
+
+      try {
+        const result = await loginSuperAdmin(db, email, password);
+        if (!result) {
+          console.log(`[AUTH] Admin login failed for email: ${email}`);
+          return errorResponse(res, 401, 'Invalid admin credentials');
+        }
+
+        return successResponse(res, result);
+      } catch (error: any) {
+        console.error(`[AUTH] Admin login error:`, error);
         return errorResponse(res, 500, `Login error: ${error?.message || 'Unknown error'}`);
       }
     },

--- a/src/routes/adminAuth.route.ts
+++ b/src/routes/adminAuth.route.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { Pool } from 'pg';
+import { createAuthController } from '../controllers/auth.controller';
+
+export function createAdminAuthRouter(db: Pool) {
+  const router = Router();
+  const controller = createAuthController(db);
+
+  router.post('/login', controller.adminLogin);
+
+  return router;
+}


### PR DESCRIPTION
## Summary
- add `loginSuperAdmin` service method
- add `adminLogin` controller handler
- create `adminAuth` router and mount at `/api/v1/admin/auth`
- document new `/api/v1/admin/auth/login` endpoint
- record the step in docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e473225cc83209ed580843ba1e8dd