### PR TITLE
Add default 404 handler

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1885,3 +1885,13 @@ Each entry is tied to a step from the implementation index.
 * `src/app.ts`
 * `docs/openapi.yaml`
 * `docs/STEP_fix_20250830.md`
+
+## [Fix - 2025-08-31] – Default 404 Handler
+
+### 🟥 Fixes
+* Unmatched routes now return JSON `{ success: false, message: 'Route not found' }` instead of HTML.
+
+### Files
+* `src/app.ts`
+* `docs/openapi.yaml`
+* `docs/STEP_fix_20250831.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -138,3 +138,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-08-28 | Backend UUID Generation | ✅ Done | `src/services/tenant.service.ts`, `src/services/admin.service.ts`, `src/services/plan.service.ts` | `docs/STEP_fix_20250828.md` |
 | fix | 2025-08-29 | Comprehensive UUID Insertion | ✅ Done | `src/services/*` | `docs/STEP_fix_20250829.md` |
 | fix | 2025-08-30 | Admin login route | ✅ Done | `src/routes/adminAuth.route.ts`, `src/controllers/auth.controller.ts`, `src/services/auth.service.ts`, `src/app.ts`, `docs/openapi.yaml` | `docs/STEP_fix_20250830.md` |
+| fix | 2025-08-31 | Default 404 handler | ✅ Done | `src/app.ts`, `docs/openapi.yaml` | `docs/STEP_fix_20250831.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -763,3 +763,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * Added dedicated `/api/v1/admin/auth/login` endpoint for SuperAdmin authentication.
 * Ensures admin logins fail fast when credentials do not match an admin user.
+
+### 🛠️ Fix 2025-08-31 – Default 404 handler
+**Status:** ✅ Done
+**Files:** `src/app.ts`, `docs/openapi.yaml`, `docs/STEP_fix_20250831.md`
+
+**Overview:**
+* Added a catch-all route that returns JSON `Route not found` errors.
+* OpenAPI spec now documents the `NotFound` response component.

--- a/docs/STEP_fix_20250831.md
+++ b/docs/STEP_fix_20250831.md
@@ -1,0 +1,16 @@
+# STEP_fix_20250831.md — Default 404 Handler
+
+## Project Context Summary
+All API endpoints are versioned under `/api/v1` and return errors via the `errorResponse` utility. However, requests to undefined routes currently return Express's default HTML 404 page instead of the JSON error structure.
+
+## Steps Already Implemented
+Admin login route and UUID fixes up to `STEP_fix_20250830.md`.
+
+## What Was Done Now
+- Added a catch-all middleware in `src/app.ts` that returns `errorResponse(res, 404, 'Route not found')`.
+- Documented the new `NotFound` response component in `docs/openapi.yaml`.
+
+## Required Documentation Updates
+- Add changelog entry.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_2_SUMMARY.md`.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1427,17 +1427,28 @@ components:
             properties:
               data:
                 type: object
-  Error:
-    description: Error response
-    content:
-      application/json:
-        schema:
-          type: object
-          properties:
-            success:
-              type: boolean
-            message:
-              type: string
+    Error:
+      description: Error response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+              message:
+                type: string
+    NotFound:
+      description: Route not found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+              message:
+                type: string
 
   schemas:
     LoginRequest:

--- a/src/app.ts
+++ b/src/app.ts
@@ -177,6 +177,10 @@ export function createApp() {
   app.use(`${API_PREFIX}/reports`, createReportsRouter(pool));
   app.use(`${API_PREFIX}/analytics`, createAnalyticsRouter(pool));
 
+  app.use('*', (_req, res) => {
+    return errorResponse(res, 404, 'Route not found');
+  });
+
   app.use(errorHandler);
   return app;
 }


### PR DESCRIPTION
## Summary
- add catch-all middleware that returns JSON error for unknown routes
- document `NotFound` response component in OpenAPI spec
- log update in CHANGELOG and implementation docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e5508ce2083209c4d221ee9528fb3