### PR TITLE
Fix env password variable

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,5 +2,5 @@ NODE_ENV=development
 DB_HOST=localhost
 DB_PORT=5432
 DB_USER=fuelsync
-DB_PASS=fuelsync
+DB_PASSWORD=fuelsync
 DB_NAME=fuelsync_hub

--- a/.env.test
+++ b/.env.test
@@ -2,7 +2,7 @@ NODE_ENV=test
 DB_HOST=localhost
 DB_PORT=5432
 DB_USER=postgres
-DB_PASS=postgres
+DB_PASSWORD=postgres
 DB_NAME=fuelsync_test
 TEST_SCHEMA=test_schema
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ db:
     - "5432:5432"
   environment:
     POSTGRES_USER: ${DB_USER}
-    POSTGRES_PASSWORD: ${DB_PASS}
+    POSTGRES_PASSWORD: ${DB_PASSWORD}
     POSTGRES_DB: ${DB_NAME}
   volumes:
     - pgdata:/var/lib/postgresql/data

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1885,3 +1885,19 @@ Each entry is tied to a step from the implementation index.
 * `src/app.ts`
 * `docs/openapi.yaml`
 * `docs/STEP_fix_20250830.md`
+
+## [Fix - 2025-08-31] – Consistent DB Password Variable
+
+### 🟥 Fixes
+* Renamed `DB_PASS` to `DB_PASSWORD` across environment files and test helpers.
+* Updated Docker Compose configuration to reference the new variable.
+
+### Files
+* `.env.development`
+* `.env.test`
+* `docker-compose.yml`
+* `jest.setup.js`
+* `jest.globalSetup.ts`
+* `jest.globalTeardown.ts`
+* `tests/utils/db-utils.ts`
+* `docs/STEP_fix_20250831.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -138,3 +138,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-08-28 | Backend UUID Generation | ✅ Done | `src/services/tenant.service.ts`, `src/services/admin.service.ts`, `src/services/plan.service.ts` | `docs/STEP_fix_20250828.md` |
 | fix | 2025-08-29 | Comprehensive UUID Insertion | ✅ Done | `src/services/*` | `docs/STEP_fix_20250829.md` |
 | fix | 2025-08-30 | Admin login route | ✅ Done | `src/routes/adminAuth.route.ts`, `src/controllers/auth.controller.ts`, `src/services/auth.service.ts`, `src/app.ts`, `docs/openapi.yaml` | `docs/STEP_fix_20250830.md` |
+| fix | 2025-08-31 | Consistent DB Password Variable | ✅ Done | `.env.development`, `.env.test`, `docker-compose.yml`, `jest.setup.js`, `jest.globalSetup.ts`, `jest.globalTeardown.ts`, `tests/utils/db-utils.ts` | `docs/STEP_fix_20250831.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -763,3 +763,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * Added dedicated `/api/v1/admin/auth/login` endpoint for SuperAdmin authentication.
 * Ensures admin logins fail fast when credentials do not match an admin user.
+
+### 🛠️ Fix 2025-08-31 – Consistent DB Password Variable
+**Status:** ✅ Done
+**Files:** `.env.development`, `.env.test`, `docker-compose.yml`, `jest.setup.js`, `jest.globalSetup.ts`, `jest.globalTeardown.ts`, `tests/utils/db-utils.ts`, `docs/STEP_fix_20250831.md`
+
+**Overview:**
+* Standardised on `DB_PASSWORD` for all environment configurations.
+* Updated Jest helpers to reference the new variable.

--- a/docs/STEP_fix_20250831.md
+++ b/docs/STEP_fix_20250831.md
@@ -1,0 +1,22 @@
+# STEP_fix_20250831.md — Consistent DB Password Variable
+
+## Project Context Summary
+In different environments the database password variable was referenced as
+`DB_PASS` or `DB_PASSWORD`. This inconsistency caused confusion when starting
+the app or running tests.
+
+## Steps Already Implemented
+All backend services use `process.env.DB_PASSWORD` as of `STEP_fix_20250830.md`.
+However development and test `.env` files, Docker compose config and Jest
+helpers still relied on `DB_PASS`.
+
+## What Was Done Now
+- Renamed `DB_PASS` to `DB_PASSWORD` in `.env.development`, `.env.test` and
+  `docker-compose.yml`.
+- Updated Jest setup scripts and test utilities to read `DB_PASSWORD`.
+- Verified no remaining uses of the old variable in the codebase.
+
+## Required Documentation Updates
+- Add changelog entry.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_2_SUMMARY.md`.

--- a/jest.globalSetup.ts
+++ b/jest.globalSetup.ts
@@ -12,7 +12,7 @@ export default async function () {
       host: process.env.DB_HOST || process.env.PGHOST,
       port: parseInt(process.env.DB_PORT || process.env.PGPORT || '5432'),
       user: process.env.DB_USER || process.env.PGUSER,
-      password: process.env.DB_PASS || process.env.PGPASSWORD,
+      password: process.env.DB_PASSWORD || process.env.PGPASSWORD,
       database: process.env.DB_NAME || process.env.PGDATABASE,
     });
     await client.connect();

--- a/jest.globalTeardown.ts
+++ b/jest.globalTeardown.ts
@@ -18,7 +18,7 @@ export default async function () {
     host: process.env.DB_HOST || process.env.PGHOST,
     port: parseInt(process.env.DB_PORT || process.env.PGPORT || '5432'),
     user: process.env.DB_USER || process.env.PGUSER,
-    password: process.env.DB_PASS || process.env.PGPASSWORD,
+    password: process.env.DB_PASSWORD || process.env.PGPASSWORD,
     database: 'postgres',
   });
   await client.connect();

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -10,7 +10,7 @@ module.exports = async () => {
     host: process.env.DB_HOST || process.env.PGHOST,
     port: parseInt(process.env.DB_PORT || process.env.PGPORT || '5432'),
     user: process.env.DB_USER || process.env.PGUSER,
-    password: process.env.DB_PASS || process.env.PGPASSWORD,
+    password: process.env.DB_PASSWORD || process.env.PGPASSWORD,
     database: process.env.DB_NAME || process.env.PGDATABASE,
   });
   await client.connect();

--- a/tests/utils/db-utils.ts
+++ b/tests/utils/db-utils.ts
@@ -7,7 +7,7 @@ export const pool = new Pool({
   host: process.env.DB_HOST || process.env.PGHOST,
   port: parseInt(process.env.DB_PORT || process.env.PGPORT || '5432'),
   user: process.env.DB_USER || process.env.PGUSER,
-  password: process.env.DB_PASS || process.env.PGPASSWORD,
+  password: process.env.DB_PASSWORD || process.env.PGPASSWORD,
   database: process.env.DB_NAME || process.env.PGDATABASE,
 });
 


### PR DESCRIPTION
## Summary
- standardize on `DB_PASSWORD` environment variable
- update Jest helpers and docker compose for the new name
- document the update in CHANGELOG and phase summaries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e55664d388320acc52c23af2b19d3