### PR TITLE
Fix debug middleware usage

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,5 @@
 NODE_ENV=development
+DEBUG_REQUESTS=true
 DB_HOST=localhost
 DB_PORT=5432
 DB_USER=fuelsync

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 NODE_ENV=production
+DEBUG_REQUESTS=false
 
 # Database Configuration
 DB_HOST=your-database-host

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -62,6 +62,12 @@ npm run dev
 # Server runs on http://localhost:3001
 ```
 
+### Debug Request Logging
+
+The server includes middleware that logs each request when `DEBUG_REQUESTS=true`.
+This middleware runs automatically when `NODE_ENV` is not `production`.
+Set `DEBUG_REQUESTS=false` to disable verbose logging.
+
 ### Step 5: Test Local API
 ```bash
 # Test health endpoint

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1919,3 +1919,17 @@ Each entry is tied to a step from the implementation index.
 * `src/app.ts`
 * `docs/openapi.yaml`
 * `docs/STEP_fix_20250901.md`
+## [Fix - 2025-09-02] – Debug middleware conditional
+
+### 🟥 Fixes
+* `debugRequest` middleware now runs only when not in production or when `DEBUG_REQUESTS=true`.
+* Added `DEBUG_REQUESTS` variable to example and development env files.
+* Documented request logging in development guide.
+
+### Files
+* `src/app.ts`
+* `.env.example`
+* `.env.development`
+* `DEV_GUIDE.md`
+* `docs/STEP_fix_20250902.md`
+

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -141,3 +141,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-08-31 | Consistent DB Password Variable | ✅ Done | `.env.development`, `.env.test`, `docker-compose.yml`, `jest.setup.js`, `jest.globalSetup.ts`, `jest.globalTeardown.ts`, `tests/utils/db-utils.ts` | `docs/STEP_fix_20250831.md` |
 | fix | 2025-08-31 | Default 404 handler | ✅ Done | `src/app.ts`, `docs/openapi.yaml` | `docs/STEP_fix_20250831.md` |
 | fix | 2025-09-01 | Secure schemas route | ✅ Done | `src/app.ts`, `docs/openapi.yaml` | `docs/STEP_fix_20250901.md` |
+| fix | 2025-09-02 | Debug middleware conditional | ✅ Done | `src/app.ts`, `.env.example`, `.env.development`, `DEV_GUIDE.md` | `docs/STEP_fix_20250902.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -786,3 +786,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * `/schemas` endpoint now only executes in non-production environments.
 * In production it requires authentication and always responds 403 without touching tables.
+### 🛠️ Fix 2025-09-02 – Debug middleware conditional
+**Status:** ✅ Done
+**Files:** `src/app.ts`, `.env.example`, `.env.development`, `DEV_GUIDE.md`, `docs/STEP_fix_20250902.md`
+
+**Overview:**
+* `debugRequest` middleware only loads when not in production or when `DEBUG_REQUESTS=true`.
+* Added `DEBUG_REQUESTS` environment variable and updated docs.
+

--- a/docs/STEP_fix_20250902.md
+++ b/docs/STEP_fix_20250902.md
@@ -1,0 +1,17 @@
+# STEP_fix_20250902.md — Debug middleware conditional
+
+## Project Context Summary
+The debug middleware prints request details for troubleshooting. It was always enabled which cluttered logs in production.
+
+## Steps Already Implemented
+Secure schemas route and default 404 handler up to `STEP_fix_20250901.md`.
+
+## What Was Done Now
+- Wrapped `app.use(debugRequest)` so it only runs when `NODE_ENV` is not `production` or `DEBUG_REQUESTS=true`.
+- Added `DEBUG_REQUESTS` variable to `.env.example` and `.env.development`.
+- Documented request logging in `DEV_GUIDE.md`.
+
+## Required Documentation Updates
+- Add changelog entry.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_2_SUMMARY.md`.

--- a/src/app.ts
+++ b/src/app.ts
@@ -155,8 +155,10 @@ export function createApp() {
 
 
   
-  // Add debug middleware
-  app.use(debugRequest);
+  // Add debug middleware in non-production or when DEBUG_REQUESTS is enabled
+  if (process.env.NODE_ENV !== 'production' || process.env.DEBUG_REQUESTS === 'true') {
+    app.use(debugRequest);
+  }
   
   // API Documentation
   app.use('/api/docs', docsRouter);


### PR DESCRIPTION
## Summary
- conditionally load debug middleware based on NODE_ENV or DEBUG_REQUESTS
- document request logging control in DEV_GUIDE
- add DEBUG_REQUESTS to example environment files
- track step in docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e593e2238832093b916e17cf2c5bc