### PR TITLE
Ignore runtime logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .env
+logs/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1933,3 +1933,13 @@ Each entry is tied to a step from the implementation index.
 * `DEV_GUIDE.md`
 * `docs/STEP_fix_20250902.md`
 
+## [Fix - 2025-09-03] – Ignore tracked log files
+
+### 🟥 Fixes
+* Removed `logs/server.log` from version control and deleted the directory.
+* Added `logs/` to `.gitignore` so runtime logs stay local.
+
+### Files
+* `.gitignore`
+* `logs/server.log` (deleted)
+* `docs/STEP_fix_20250903.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -142,3 +142,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-08-31 | Default 404 handler | ✅ Done | `src/app.ts`, `docs/openapi.yaml` | `docs/STEP_fix_20250831.md` |
 | fix | 2025-09-01 | Secure schemas route | ✅ Done | `src/app.ts`, `docs/openapi.yaml` | `docs/STEP_fix_20250901.md` |
 | fix | 2025-09-02 | Debug middleware conditional | ✅ Done | `src/app.ts`, `.env.example`, `.env.development`, `DEV_GUIDE.md` | `docs/STEP_fix_20250902.md` |
+| fix | 2025-09-03 | Ignore runtime logs | ✅ Done | `.gitignore`, `logs/server.log` (deleted) | `docs/STEP_fix_20250903.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -794,3 +794,9 @@ sudo apt-get update && sudo apt-get install -y postgresql
 * `debugRequest` middleware only loads when not in production or when `DEBUG_REQUESTS=true`.
 * Added `DEBUG_REQUESTS` environment variable and updated docs.
 
+### 🛠️ Fix 2025-09-03 – Log directory cleanup
+**Status:** ✅ Done
+**Files:** `.gitignore`, `docs/STEP_fix_20250903.md`
+
+**Overview:**
+* Removed obsolete `logs/server.log` and added the directory to `.gitignore` to keep runtime logs out of version control.

--- a/docs/STEP_fix_20250903.md
+++ b/docs/STEP_fix_20250903.md
@@ -1,0 +1,17 @@
+# STEP_fix_20250903.md — Log directory cleanup
+
+## Project Context Summary
+Runtime server logs were previously committed to the repository under `logs/server.log`.
+Keeping log files in version control bloats the repository and exposes potentially sensitive information.
+
+## Steps Already Implemented
+The last fix (`STEP_fix_20250902.md`) adjusted debug middleware configuration and environment variables.
+
+## What Was Done Now
+- Added `logs/` to `.gitignore` so runtime logs aren't tracked.
+- Removed `logs/server.log` from the repository and deleted the empty directory.
+
+## Required Documentation Updates
+- Add changelog entry.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_2_SUMMARY.md`.

--- a/logs/server.log
+++ b/logs/server.log
@@ -1,4 +1,0 @@
-[36mStarting FuelSync API server...[0m
-[33mChecking for TypeScript errors...[0m
-[32mTypeScript check passed![0m
-[36mStarting server...[0m


### PR DESCRIPTION
## Summary
- avoid committing runtime logs by ignoring `logs/`
- remove existing `server.log`
- document cleanup in CHANGELOG
- add step file and update implementation index and phase summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e5aa52b8483209a30448e49bb4cc2