### PR TITLE
Fix tenant creation updated_at bug

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1953,3 +1953,12 @@ Each entry is tied to a step from the implementation index.
 * `OWNER_ROLE_IMPLEMENTATION.md`
 * `docs/IMPLEMENTATION_INDEX.md`
 
+
+## [Fix - 2025-09-05] – Tenant creation updated_at bug
+
+### 🟥 Fixes
+* Insert query for new tenants now sets `updated_at` to `NOW()` to satisfy not-null constraint.
+
+### Files
+* `src/services/tenant.service.ts`
+* `docs/STEP_fix_20250905.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -144,3 +144,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-09-02 | Debug middleware conditional | ✅ Done | `src/app.ts`, `.env.example`, `.env.development`, `DEV_GUIDE.md` | `docs/STEP_fix_20250902.md` |
 | fix | 2025-09-03 | Ignore runtime logs | ✅ Done | `.gitignore`, `logs/server.log` (deleted) | `docs/STEP_fix_20250903.md` |
 | fix | 2025-09-04 | Owner doc filename typo | ✅ Done | `OWNER_ROLE_IMPLEMENTATION.md` | `docs/STEP_fix_20250904.md` |
+| fix | 2025-09-05 | Tenant creation updated_at bug | ✅ Done | `src/services/tenant.service.ts` | `docs/STEP_fix_20250905.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -800,3 +800,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Removed obsolete `logs/server.log` and added the directory to `.gitignore` to keep runtime logs out of version control.
+
+### 🛠️ Fix 2025-09-05 – Tenant creation updated_at bug
+**Status:** ✅ Done
+**Files:** `src/services/tenant.service.ts`, `docs/STEP_fix_20250905.md`
+
+**Overview:**
+* Insert query now populates the `updated_at` column to prevent 500 errors when creating tenants.

--- a/docs/STEP_fix_20250905.md
+++ b/docs/STEP_fix_20250905.md
@@ -1,0 +1,15 @@
+# STEP_fix_20250905.md — Updated_at insertion for tenants
+
+## Project Context Summary
+Creating a tenant via `/api/v1/admin/tenants` returned a database error: `null value in column "updated_at" of relation "tenants"`. The insert query in `createTenant` omitted the `updated_at` column, causing failures when the database requires a value.
+
+## Steps Already Implemented
+The previous step (`STEP_fix_20250904.md`) corrected a documentation filename.
+
+## What Was Done Now
+- Modified `src/services/tenant.service.ts` to explicitly set `updated_at = NOW()` when inserting a new tenant.
+
+## Required Documentation Updates
+- Add changelog entry.
+- Append to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_2_SUMMARY.md`.

--- a/src/services/tenant.service.ts
+++ b/src/services/tenant.service.ts
@@ -47,7 +47,7 @@ export async function createTenant(db: Pool, input: TenantInput): Promise<Tenant
 
     const tenantId = randomUUID();
     const result = await client.query(
-      'INSERT INTO public.tenants (id, name, plan_id, status) VALUES ($1, $2, $3, $4) RETURNING id, name, plan_id, status, created_at',
+      'INSERT INTO public.tenants (id, name, plan_id, status, updated_at) VALUES ($1, $2, $3, $4, NOW()) RETURNING id, name, plan_id, status, created_at, updated_at',
       [tenantId, input.name, input.planId, 'active']
     );
 


### PR DESCRIPTION
## Summary
- ensure updated_at is set when creating a tenant
- document the fix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e5d92df2c8320a6844ba2b71f3c68