### PR TITLE
Fix credential documentation

### DIFF
--- a/AZURE_DEPLOYMENT.md
+++ b/AZURE_DEPLOYMENT.md
@@ -53,10 +53,10 @@ x-tenant-id: production_tenant
 ### 1. Login Credentials
 
 ```
-SuperAdmin: admin@fuelsync.com / admin123
-Owner: owner@fuelsync.com / admin123
-Manager: manager@fuelsync.com / admin123
-Attendant: attendant@fuelsync.com / admin123
+SuperAdmin: admin@fuelsync.com / Admin@123
+Owner: owner@fuelsync.com / Admin@123
+Manager: manager@fuelsync.com / Admin@123
+Attendant: attendant@fuelsync.com / Admin@123
 ```
 
 ### 2. Test API Endpoints

--- a/DEPLOYMENT_FIX.md
+++ b/DEPLOYMENT_FIX.md
@@ -34,10 +34,10 @@
 ## Testing the API
 
 ### Login Credentials
-- **SuperAdmin:** `admin@fuelsync.com / admin123`
-- **Owner:** `owner@fuelsync.com / admin123`
-- **Manager:** `manager@fuelsync.com / admin123`
-- **Attendant:** `attendant@fuelsync.com / admin123`
+- **SuperAdmin:** `admin@fuelsync.com / Admin@123`
+- **Owner:** `owner@fuelsync.com / Admin@123`
+- **Manager:** `manager@fuelsync.com / Admin@123`
+- **Attendant:** `attendant@fuelsync.com / Admin@123`
 
 ### Important Headers
 When making API requests, include:

--- a/TENANT_CONTEXT_FIX.md
+++ b/TENANT_CONTEXT_FIX.md
@@ -104,14 +104,14 @@ Each tenant has its own schema with tables:
 
 ### User Credentials
 **Super Admin:**
-- `admin@fuelsync.com` / `admin123`
-- `admin2@fuelsync.com` / `admin123`
-- `support@fuelsync.com` / `admin123`
+- `admin@fuelsync.com` / `Admin@123`
+- `admin2@fuelsync.com` / `Admin@123`
+- `support@fuelsync.com` / `Admin@123`
 
 **Production Tenant:**
-- `owner@production-tenant.com` / `admin123`
-- `manager@production-tenant.com` / `admin123`
-- `attendant@production-tenant.com` / `admin123`
+- `owner@production-tenant.com` / `Admin@123`
+- `manager@production-tenant.com` / `Admin@123`
+- `attendant@production-tenant.com` / `Admin@123`
 
 ## Testing
 
@@ -119,14 +119,14 @@ Each tenant has its own schema with tables:
 ```bash
 curl -X POST http://localhost:3000/api/v1/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email":"admin@fuelsync.com","password":"admin123"}'
+  -d '{"email":"admin@fuelsync.com","password":"Admin@123"}'
 ```
 
 ### 2. Tenant Owner Login
 ```bash
 curl -X POST http://localhost:3000/api/v1/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email":"owner@production-tenant.com","password":"admin123"}'
+  -d '{"email":"owner@production-tenant.com","password":"Admin@123"}'
 ```
 
 ### 3. Owner Create Station

--- a/TENANT_UUID_FIX_SUMMARY.md
+++ b/TENANT_UUID_FIX_SUMMARY.md
@@ -87,7 +87,7 @@ tenant_id  UUID REFERENCES public.tenants(id)  -- Must be UUID, not schema name
 ```bash
 curl -X POST http://localhost:3000/api/v1/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email":"owner@production-tenant.com","password":"admin123"}'
+  -d '{"email":"owner@production-tenant.com","password":"Admin@123"}'
 ```
 
 ### 2. Create Station (should work now)

--- a/docs/AZURE_DEPLOYMENT_GUIDE.md
+++ b/docs/AZURE_DEPLOYMENT_GUIDE.md
@@ -39,13 +39,13 @@ npm run update-azure-seed # Add SuperAdmin test data
 ### Login Credentials
 
 ```
-SuperAdmin: admin@fuelsync.com / admin123
-SuperAdmin: admin2@fuelsync.com / admin123
-Admin: support@fuelsync.com / admin123
+SuperAdmin: admin@fuelsync.com / Admin@123
+SuperAdmin: admin2@fuelsync.com / Admin@123
+Admin: support@fuelsync.com / Admin@123
 
-Owner: owner@fuelsync.com / admin123
-Manager: manager@fuelsync.com / admin123
-Attendant: attendant@fuelsync.com / admin123
+Owner: owner@fuelsync.com / Admin@123
+Manager: manager@fuelsync.com / Admin@123
+Attendant: attendant@fuelsync.com / Admin@123
 ```
 
 ### Test API Endpoints

--- a/docs/AZURE_DEPLOYMENT_UPDATED.md
+++ b/docs/AZURE_DEPLOYMENT_UPDATED.md
@@ -40,7 +40,7 @@ npm run setup-db
 Login as SuperAdmin:
 - URL: https://fuelsync-frontend.azurewebsites.net/login
 - Email: `admin@fuelsync.com`
-- Password: `admin123`
+- Password: `Admin@123`
 
 You should see:
 - Dashboard with tenant metrics
@@ -53,7 +53,7 @@ You should see:
 Login as Owner:
 - URL: https://fuelsync-frontend.azurewebsites.net/login
 - Email: `owner@production-tenant.com`
-- Password: `admin123`
+- Password: `Admin@123`
 
 You should see:
 - Dashboard with station metrics

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1962,3 +1962,15 @@ Each entry is tied to a step from the implementation index.
 ### Files
 * `src/services/tenant.service.ts`
 * `docs/STEP_fix_20250905.md`
+
+## [Fix - 2025-09-06] – Credential consistency
+
+### 🟥 Fixes
+* Updated all docs and setup scripts to use `Admin@123` as the default password.
+* Seed scripts and service now hash `Admin@123` by default and logs display the correct credentials.
+
+### Files
+* `src/services/admin.service.ts`
+* `scripts/setup-database.js`
+* Various documentation files
+* `docs/STEP_fix_20250906.md`

--- a/docs/DATABASE_SETUP.md
+++ b/docs/DATABASE_SETUP.md
@@ -65,14 +65,14 @@ Each tenant has its own schema with these tables:
 ## Login Credentials
 
 ### SuperAdmin Users
-- `admin@fuelsync.com / admin123`
-- `admin2@fuelsync.com / admin123`
-- `support@fuelsync.com / admin123` (Admin role)
+- `admin@fuelsync.com / Admin@123`
+- `admin2@fuelsync.com / Admin@123`
+- `support@fuelsync.com / Admin@123` (Admin role)
 
 ### Tenant Users
-- `owner@production-tenant.com / admin123`
-- `manager@production-tenant.com / admin123`
-- `attendant@production-tenant.com / admin123`
+- `owner@production-tenant.com / Admin@123`
+- `manager@production-tenant.com / Admin@123`
+- `attendant@production-tenant.com / Admin@123`
 
 ## Tenant Structure
 

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -145,3 +145,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-09-03 | Ignore runtime logs | ✅ Done | `.gitignore`, `logs/server.log` (deleted) | `docs/STEP_fix_20250903.md` |
 | fix | 2025-09-04 | Owner doc filename typo | ✅ Done | `OWNER_ROLE_IMPLEMENTATION.md` | `docs/STEP_fix_20250904.md` |
 | fix | 2025-09-05 | Tenant creation updated_at bug | ✅ Done | `src/services/tenant.service.ts` | `docs/STEP_fix_20250905.md` |
+| fix | 2025-09-06 | Credential consistency | ✅ Done | `src/services/admin.service.ts`, `scripts/setup-database.js`, docs | `docs/STEP_fix_20250906.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -807,3 +807,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Insert query now populates the `updated_at` column to prevent 500 errors when creating tenants.
+
+### 🛠️ Fix 2025-09-06 – Credential consistency
+**Status:** ✅ Done
+**Files:** `src/services/admin.service.ts`, `scripts/setup-database.js`, `docs/STEP_fix_20250906.md`
+
+**Overview:**
+* All documentation and setup scripts now reference `Admin@123` as the default password, resolving login issues caused by outdated credentials.

--- a/docs/STEP_fix_20250906.md
+++ b/docs/STEP_fix_20250906.md
@@ -1,0 +1,16 @@
+# STEP_fix_20250906.md — Credential consistency
+
+## Project Context Summary
+Several deployment docs referenced the default password `admin123` for all roles. However, the latest seed scripts use `Admin@123`. This mismatch caused login failures when following the outdated documentation.
+
+## Steps Already Implemented
+The previous step (`STEP_fix_20250905.md`) fixed the tenant creation `updated_at` bug.
+
+## What Was Done Now
+- Updated all documentation files to show `Admin@123` as the default password.
+- Updated `src/services/admin.service.ts` and `scripts/setup-database.js` to use `Admin@123` and print the correct credentials.
+
+## Required Documentation Updates
+- Add changelog entry.
+- Append to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_2_SUMMARY.md`.

--- a/docs/TENANT_RELATIONSHIP_FIX.md
+++ b/docs/TENANT_RELATIONSHIP_FIX.md
@@ -36,13 +36,13 @@
 ## Testing the Fix
 
 ### 1. SuperAdmin View
-- Login as SuperAdmin: `admin@fuelsync.com / admin123`
+- Login as SuperAdmin: `admin@fuelsync.com / Admin@123`
 - Navigate to Tenants page
 - Verify all tenants are visible
 - Click on a tenant to see its details
 
 ### 2. Owner View
-- Login as Owner: `owner@fuelsync.com / admin123`
+- Login as Owner: `owner@fuelsync.com / Admin@123`
 - Verify stations are visible
 - Navigate through stations → pumps → nozzles
 

--- a/scripts/setup-database.js
+++ b/scripts/setup-database.js
@@ -112,7 +112,7 @@ async function setupDatabase() {
     // STEP 3: Create admin users
     console.log('\n=== STEP 3: Creating admin users ===');
     
-    const adminHash = await bcrypt.hash('admin123', 10);
+    const adminHash = await bcrypt.hash('Admin@123', 10);
     
     // Create main admin
     await pool.query(`
@@ -192,7 +192,7 @@ async function setupDatabase() {
       console.log(`\nCreating data for tenant: ${tenant.name}`);
       
       // Create users
-      const userHash = await bcrypt.hash('admin123', 10);
+      const userHash = await bcrypt.hash('Admin@123', 10);
       
       // Create owner with domain-friendly email
       const emailPrefix = tenant.slug;
@@ -406,13 +406,13 @@ async function setupDatabase() {
     
     console.log('\n=== Database setup completed successfully ===');
     console.log('\nLogin credentials:');
-    console.log('SuperAdmin: admin@fuelsync.com / admin123');
-    console.log('SuperAdmin: admin2@fuelsync.com / admin123');
-    console.log('Admin: support@fuelsync.com / admin123');
+    console.log('SuperAdmin: admin@fuelsync.com / Admin@123');
+    console.log('SuperAdmin: admin2@fuelsync.com / Admin@123');
+    console.log('Admin: support@fuelsync.com / Admin@123');
     console.log('\nTenant credentials:');
-    console.log('Owner: owner@production-tenant.com / admin123');
-    console.log('Manager: manager@production-tenant.com / admin123');
-    console.log('Attendant: attendant@production-tenant.com / admin123');
+    console.log('Owner: owner@production-tenant.com / Admin@123');
+    console.log('Manager: manager@production-tenant.com / Admin@123');
+    console.log('Attendant: attendant@production-tenant.com / Admin@123');
     
   } catch (error) {
     console.error('Error setting up database:', error);

--- a/src/services/admin.service.ts
+++ b/src/services/admin.service.ts
@@ -32,7 +32,7 @@ export async function createAdminUser(db: Pool, input: AdminUserInput): Promise<
   }
   
   // Hash password
-  const passwordHash = await bcrypt.hash(input.password || 'admin123', 10);
+  const passwordHash = await bcrypt.hash(input.password || 'Admin@123', 10);
   
   const result = await db.query(
     'INSERT INTO public.admin_users (id, email, name, password_hash, role) VALUES ($1, $2, $3, $4, $5) RETURNING id, email, name, role, created_at',


### PR DESCRIPTION
## Summary
- update all docs to use `Admin@123`
- update setup script and admin service to use the new default password
- log corrected credentials
- document change in PHASE_2_SUMMARY and CHANGELOG
- record fix step in IMPLEMENTATION_INDEX

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e6aff42b48320bb282460b01fc0cc