### PR TITLE
Map plan UUIDs to rule presets and add pump limit tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1982,3 +1982,26 @@ Each entry is tied to a step from the implementation index.
 * `scripts/setup-database.js`
 * Various documentation files
 * `docs/STEP_fix_20250906.md`
+
+## [Fix - 2025-06-28] – Login test updates and schema fixes
+
+### 🟥 Fixes
+* Login test script now uses seeded credentials and supports custom port.
+* Unified schema migrations run cleanly on fresh databases.
+
+### Files
+* `scripts/simple-login-test.js`
+* `migrations/schema/003_unified_schema.sql`
+* `migrations/schema/005_master_unified_schema.sql`
+* `docs/STEP_fix_20250628.md`
+
+## [Fix - 2025-06-29] – Plan rule lookup by UUID
+
+### 🟥 Fixes
+* `getPlanRules` now maps seeded plan UUIDs to rule presets, preventing false limit errors.
+* Added unit tests for pump plan enforcement.
+
+### Files
+* `src/config/planConfig.ts`
+* `tests/planEnforcement.test.ts`
+* `docs/STEP_fix_20250629.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -147,3 +147,5 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-09-05 | Tenant creation updated_at bug | ✅ Done | `src/services/tenant.service.ts` | `docs/STEP_fix_20250905.md` |
 | fix | 2025-09-06 | User creation updated_at bug | ✅ Done | `src/services/user.service.ts`, `src/services/tenant.service.ts` | `docs/STEP_fix_20250906.md` |
 | fix | 2025-09-06 | Credential consistency | ✅ Done | `src/services/admin.service.ts`, `scripts/setup-database.js`, docs | `docs/STEP_fix_20250906.md` |
+| fix | 2025-06-28 | Login tests & schema patch | ✅ Done | `scripts/simple-login-test.js`, `migrations/schema/003_unified_schema.sql`, `migrations/schema/005_master_unified_schema.sql` | `docs/STEP_fix_20250628.md` |
+| fix | 2025-06-29 | Plan rule lookup by UUID | ✅ Done | `src/config/planConfig.ts`, `tests/planEnforcement.test.ts` | `docs/STEP_fix_20250629.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -820,3 +820,20 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * All documentation and setup scripts now reference `Admin@123` as the default password, resolving login issues caused by outdated credentials.
+
+### 🛠️ Fix 2025-06-28 – Login tests & schema migration
+**Status:** ✅ Done
+**Files:** `scripts/simple-login-test.js`, `migrations/schema/003_unified_schema.sql`, `migrations/schema/005_master_unified_schema.sql`, `docs/STEP_fix_20250628.md`
+
+**Overview:**
+* Updated login test script to match seeded user credentials and configurable port.
+* Unified schema SQL adjusted for clean initialization.
+
+### 🛠️ Fix 2025-06-29 – Plan rule lookup by UUID
+**Status:** ✅ Done
+**Files:** `src/config/planConfig.ts`, `tests/planEnforcement.test.ts`, `docs/STEP_fix_20250629.md`
+
+**Overview:**
+* `getPlanRules` now resolves plan rules using the seeded plan UUIDs.
+* Added Jest tests covering pump limit enforcement.
+

--- a/docs/STEP_fix_20250628.md
+++ b/docs/STEP_fix_20250628.md
@@ -1,0 +1,19 @@
+# STEP_fix_20250628.md — Login Tests & Schema Patch
+
+## Project Context Summary
+Earlier migration scripts failed on fresh databases and the login test used outdated credentials. This blocked verification of API functionality in clean environments.
+
+## Steps Already Implemented
+- Unified database setup scripts (`setup-unified-db.js`, `apply-unified-schema.js`).
+- Seeding scripts for demo data.
+
+## What Was Done Now
+1. Fixed `003_unified_schema.sql` to skip dropping `pg_toast`.
+2. Reordered table creation in `005_master_unified_schema.sql` so foreign keys resolve.
+3. Updated `scripts/simple-login-test.js` with seeded credentials and configurable port.
+4. Validated database setup and login flow locally.
+
+## Required Documentation Updates
+- Add entry in `CHANGELOG.md` under Fixes.
+- Append summary in `PHASE_2_SUMMARY.md`.
+- Add row in `IMPLEMENTATION_INDEX.md`.

--- a/docs/STEP_fix_20250629.md
+++ b/docs/STEP_fix_20250629.md
@@ -1,0 +1,18 @@
+# STEP_fix_20250629.md — Plan ID mapping for enforcement
+
+## Project Context Summary
+Plan limit enforcement always fell back to the starter rules because `getPlanRules` expected string keys like `starter`, but plans are seeded with UUIDs. Demo tenants therefore hit limits prematurely.
+
+## Steps Already Implemented
+- Middleware helpers in `planEnforcement.ts` enforce limits on creation.
+- Seed script provisions three plans with fixed UUIDs.
+- Previous fix updated login tests and schema ordering.
+
+## What Was Done Now
+1. Mapped seeded plan UUIDs to rule presets in `planConfig.ts`.
+2. Added unit tests (`tests/planEnforcement.test.ts`) validating pump creation limits.
+
+## Required Documentation Updates
+- Append changelog entry.
+- Update `IMPLEMENTATION_INDEX.md` and `PHASE_2_SUMMARY.md` with this fix.
+

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -33,3 +33,5 @@ Service tests mock database calls while integration tests create and drop a dedi
 Sample coverage includes authentication, nozzle readings, creditors and reconciliation logic. E2E tests verify the login flow and protected routes.
 
 Creditor service tests validate balance logic in `tests/creditor.service.test.ts`.
+Plan enforcement logic is covered in `tests/planEnforcement.test.ts`, which mocks database calls to verify pump creation limits.
+

--- a/migrations/schema/003_unified_schema.sql
+++ b/migrations/schema/003_unified_schema.sql
@@ -57,7 +57,7 @@ DECLARE
 BEGIN
     FOR r IN
         SELECT nspname FROM pg_namespace
-        WHERE nspname NOT IN ('public', 'pg_catalog', 'information_schema')
+        WHERE nspname NOT IN ('public', 'pg_catalog', 'information_schema', 'pg_toast')
     LOOP
         EXECUTE format('DROP SCHEMA IF EXISTS %I CASCADE;', r.nspname);
     END LOOP;

--- a/migrations/schema/005_master_unified_schema.sql
+++ b/migrations/schema/005_master_unified_schema.sql
@@ -124,6 +124,17 @@ CREATE TABLE IF NOT EXISTS public.creditors (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+CREATE TABLE IF NOT EXISTS public.nozzle_readings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  nozzle_id UUID NOT NULL REFERENCES public.nozzles(id) ON DELETE CASCADE,
+  reading DECIMAL(10,2) NOT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL,
+  payment_method TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
 CREATE TABLE IF NOT EXISTS public.sales (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
@@ -193,17 +204,6 @@ CREATE TABLE IF NOT EXISTS public.fuel_deliveries (
   volume DECIMAL(10,3) NOT NULL CHECK (volume > 0),
   delivered_by TEXT,
   delivery_date DATE NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
-CREATE TABLE IF NOT EXISTS public.nozzle_readings (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
-  nozzle_id UUID NOT NULL REFERENCES public.nozzles(id) ON DELETE CASCADE,
-  reading DECIMAL(10,2) NOT NULL,
-  recorded_at TIMESTAMPTZ NOT NULL,
-  payment_method TEXT,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/scripts/simple-login-test.js
+++ b/scripts/simple-login-test.js
@@ -34,10 +34,8 @@ function checkServer(host, port) {
 
 // Test credentials
 const testUsers = [
-  { role: 'superadmin', email: 'admin@fuelsync.dev', password: 'password' },
-  { role: 'owner', email: 'owner@demo.com', password: 'password' },
-  { role: 'manager', email: 'manager@demo.com', password: 'password' },
-  { role: 'attendant', email: 'attendant@demo.com', password: 'password' }
+  { role: 'superadmin', email: 'admin@fuelsync.com', password: 'Admin@123' },
+  { role: 'owner', email: 'owner@demofuels.com', password: 'Owner@123' }
 ];
 
 // API URL
@@ -62,14 +60,14 @@ async function testLogin(email, password) {
     console.log('Response headers:', response.headers);
     console.log('Response data:', response.data);
     
-    if (response.status === 200 && response.data.token) {
+    if (response.status === 200 && response.data && response.data.data && response.data.data.token) {
       console.log('Login successful!');
-      console.log('Token:', response.data.token ? '✓ Present' : '✗ Missing');
-      console.log('User:', response.data.user ? '✓ Present' : '✗ Missing');
-      if (response.data.user) {
-        console.log('User ID:', response.data.user.id);
-        console.log('User Role:', response.data.user.role);
-        console.log('Tenant ID:', response.data.user.tenantId || 'N/A');
+      console.log('Token:', response.data.data.token ? '✓ Present' : '✗ Missing');
+      console.log('User:', response.data.data.user ? '✓ Present' : '✗ Missing');
+      if (response.data.data.user) {
+        console.log('User ID:', response.data.data.user.id);
+        console.log('User Role:', response.data.data.user.role);
+        console.log('Tenant ID:', response.data.data.user.tenantId || 'N/A');
       }
       return true;
     } else {
@@ -92,7 +90,8 @@ async function testLogin(email, password) {
 async function runTests() {
   try {
     // Check if server is running
-    const serverRunning = await checkServer('localhost', 3000);
+    const port = process.env.PORT ? parseInt(process.env.PORT) : 3000;
+    const serverRunning = await checkServer('localhost', port);
     if (!serverRunning) {
       console.error('\n⚠️ Server is not running! Please start the server with: npm start');
       return;

--- a/src/config/planConfig.ts
+++ b/src/config/planConfig.ts
@@ -8,6 +8,7 @@ export interface PlanRules {
   enableApiAccess: boolean;
 }
 
+// Built-in rule presets
 export const planConfig: Record<string, PlanRules> = {
   starter: {
     maxStations: 1,
@@ -38,6 +39,14 @@ export const planConfig: Record<string, PlanRules> = {
   },
 };
 
+// Map seeded UUIDs to rule presets
+const planIdMap: Record<string, keyof typeof planConfig> = {
+  '00000000-0000-0000-0000-000000000001': 'starter',
+  '00000000-0000-0000-0000-000000000002': 'pro',
+  '00000000-0000-0000-0000-000000000003': 'enterprise',
+};
+
 export function getPlanRules(planId: string): PlanRules {
-  return planConfig[planId] || planConfig.starter;
+  const key = planIdMap[planId] || planId;
+  return planConfig[key] || planConfig.starter;
 }

--- a/tests/planEnforcement.test.ts
+++ b/tests/planEnforcement.test.ts
@@ -1,0 +1,27 @@
+import { beforeCreatePump } from '../src/middleware/planEnforcement';
+
+describe('planEnforcement.beforeCreatePump', () => {
+  test('allows pump creation when under limit', async () => {
+    const client = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ plan_id: '00000000-0000-0000-0000-000000000002' }] })
+        .mockResolvedValueOnce({ rows: [{ count: '3' }] }),
+      release: jest.fn(),
+    } as any;
+
+    await expect(beforeCreatePump(client, 't1', 's1')).resolves.not.toThrow();
+  });
+
+  test('throws error when pump limit reached', async () => {
+    const client = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ plan_id: '00000000-0000-0000-0000-000000000002' }] })
+        .mockResolvedValueOnce({ rows: [{ count: '8' }] }),
+      release: jest.fn(),
+    } as any;
+
+    await expect(beforeCreatePump(client, 't1', 's1')).rejects.toThrow('Plan limit exceeded');
+  });
+});


### PR DESCRIPTION
## Summary
- map seeded plan UUIDs in `getPlanRules`
- add unit test for pump plan enforcement
- document plan ID fix and test coverage

## Testing
- `npm test` *(prints "Tests not available in this environment")*

------
https://chatgpt.com/codex/tasks/task_e_685e7239387c8320b58778447e99e32a