### PR TITLE
Fix sales endpoint numeric parsing across services

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2120,3 +2120,23 @@ Each entry is tied to a step from the implementation index.
 ### Files
 * `src/controllers/nozzleReading.controller.ts`
 * `docs/STEP_fix_20250916.md`
+
+## [Fix - 2025-09-17] – Sales listing numeric values
+
+### 🟥 Fixes
+* `listSales` now parses `volume` and `amount` as numbers to match the `Sale` schema.
+
+### Files
+* `src/services/sales.service.ts`
+* `docs/STEP_fix_20250917.md`
+
+## [Fix - 2025-09-18] – Numeric and date parsing
+
+### 🟥 Fixes
+* Added `parseDb` helper to convert numeric and timestamp strings across services.
+* All service listings now return numbers and `Date` objects instead of strings.
+
+### Files
+* `src/utils/parseDb.ts`
+* `src/services/*`
+* `docs/STEP_fix_20250918.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -159,3 +159,5 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-09-14 | Explicit updated_at on inserts | ✅ Done | `src/services/*` | `docs/STEP_fix_20250914.md` |
 | fix | 2025-09-15 | Unified sales storage | ✅ Done | `src/services/nozzleReading.service.ts`, `src/services/reconciliation.service.ts`, `src/controllers/reconciliation.controller.ts`, `src/controllers/dashboard.controller.ts`, `src/controllers/reports.controller.ts` | `docs/STEP_fix_20250915.md` |
 | fix | 2025-09-16 | Nozzle reading service wiring | ✅ Done | `src/controllers/nozzleReading.controller.ts` | `docs/STEP_fix_20250916.md` |
+| fix | 2025-09-17 | Sales listing numeric values | ✅ Done | `src/services/sales.service.ts` | `docs/STEP_fix_20250917.md` |
+| fix | 2025-09-18 | Numeric and date parsing | ✅ Done | `src/utils/parseDb.ts`, `src/services/*` | `docs/STEP_fix_20250918.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -909,3 +909,17 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * The nozzle reading API now calls the service layer so each reading also creates a sales row in `public.sales`.
+
+### 🛠️ Fix 2025-09-17 – Sales listing numeric values
+**Status:** ✅ Done
+**Files:** `src/services/sales.service.ts`, `docs/STEP_fix_20250917.md`
+
+**Overview:**
+* `listSales` now converts `volume` and `amount` with `parseFloat` so API responses use numeric types.
+
+### 🛠️ Fix 2025-09-18 – Numeric and date parsing
+**Status:** ✅ Done
+**Files:** `src/utils/parseDb.ts`, `src/services/*`, `docs/STEP_fix_20250918.md`
+
+**Overview:**
+* Introduced a shared parser so all service methods return numbers and `Date` objects rather than strings.

--- a/docs/STEP_fix_20250917.md
+++ b/docs/STEP_fix_20250917.md
@@ -1,0 +1,15 @@
+# STEP_fix_20250917.md — Sales listing numeric values
+
+## Project Context Summary
+The sales listing API (`listSales`) returned `volume` and `amount` as strings from Postgres. This caused type mismatches with the `Sale` schema expecting numbers.
+
+## Steps Already Implemented
+All fixes through `STEP_fix_20250916.md`.
+
+## What Was Done Now
+- Updated `listSales` in `src/services/sales.service.ts` to map database rows and parse `volume` and `amount` using `parseFloat`.
+
+## Required Documentation Updates
+- Add changelog entry.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_2_SUMMARY.md`.

--- a/docs/STEP_fix_20250918.md
+++ b/docs/STEP_fix_20250918.md
@@ -1,0 +1,16 @@
+# STEP_fix_20250918.md — Parse numeric and date fields
+
+## Project Context Summary
+Previous endpoints returned numeric and timestamp columns as strings from Postgres. Only `listSales` parsed a few fields. API consumers expect numbers and JavaScript `Date` objects.
+
+## Steps Already Implemented
+All fixes through `STEP_fix_20250917.md` including numeric parsing for sales listing.
+
+## What Was Done Now
+- Added `parseDb` utility to convert string numbers and ISO date strings.
+- Updated all service functions that return database rows to use this helper so numeric and date fields are properly typed.
+
+## Required Documentation Updates
+- Changelog entry under Fixes.
+- Implementation index row.
+- Phase summary update.

--- a/docs/STEP_fix_20250918_COMMAND.md
+++ b/docs/STEP_fix_20250918_COMMAND.md
@@ -1,0 +1,18 @@
+# STEP_fix_20250918_COMMAND.md
+
+## Project Context Summary
+FuelSync Hub returns string values for numeric and date columns from the Postgres driver. A previous fix converted only sales volume and amount. All endpoints should return correctly typed values.
+
+## Steps Already Implemented
+See `IMPLEMENTATION_INDEX.md` up to `STEP_fix_20250917.md`.
+
+## What to Build Now
+- Create a utility to parse numbers and ISO dates from query results.
+- Apply this utility across all service functions that return rows or single row objects.
+- Ensure no API returns numeric or date strings.
+- Update docs: changelog, phase summary, implementation index.
+
+## Required Documentation Updates
+- Append fix entry to `CHANGELOG.md`.
+- Mark fix done in `PHASE_2_SUMMARY.md`.
+- Add row to `IMPLEMENTATION_INDEX.md`.

--- a/src/services/admin.service.ts
+++ b/src/services/admin.service.ts
@@ -1,6 +1,7 @@
 import { Pool } from 'pg';
 import bcrypt from 'bcrypt';
 import { randomUUID } from 'crypto';
+import { parseRow, parseRows } from '../utils/parseDb';
 
 export interface AdminUserInput {
   email: string;
@@ -39,14 +40,7 @@ export async function createAdminUser(db: Pool, input: AdminUserInput): Promise<
     [randomUUID(), input.email, input.name || input.email.split('@')[0], passwordHash, input.role || 'superadmin']
   );
   
-  const user = result.rows[0];
-  return {
-    id: user.id,
-    email: user.email,
-    name: user.name,
-    role: user.role,
-    createdAt: user.created_at
-  };
+  return parseRow(result.rows[0]);
 }
 
 /**
@@ -57,13 +51,7 @@ export async function listAdminUsers(db: Pool): Promise<AdminUserOutput[]> {
     'SELECT id, email, name, role, created_at FROM public.admin_users ORDER BY created_at DESC'
   );
   
-  return result.rows.map(user => ({
-    id: user.id,
-    email: user.email,
-    name: user.name,
-    role: user.role,
-    createdAt: user.created_at
-  }));
+  return parseRows(result.rows);
 }
 
 /**
@@ -79,14 +67,7 @@ export async function getAdminUser(db: Pool, id: string): Promise<AdminUserOutpu
     return null;
   }
   
-  const user = result.rows[0];
-  return {
-    id: user.id,
-    email: user.email,
-    name: user.name,
-    role: user.role,
-    createdAt: user.created_at
-  };
+  return parseRow(result.rows[0]);
 }
 
 /**
@@ -131,14 +112,7 @@ export async function updateAdminUser(db: Pool, id: string, input: AdminUserInpu
     throw new Error('Admin user not found');
   }
   
-  const user = result.rows[0];
-  return {
-    id: user.id,
-    email: user.email,
-    name: user.name,
-    role: user.role,
-    createdAt: user.created_at
-  };
+  return parseRow(result.rows[0]);
 }
 
 /**

--- a/src/services/adminUser.service.ts
+++ b/src/services/adminUser.service.ts
@@ -2,6 +2,7 @@ import { Pool } from 'pg';
 import { randomUUID } from 'crypto';
 import bcrypt from 'bcrypt';
 import { UserRole } from '../constants/auth';
+import { parseRows } from '../utils/parseDb';
 
 export async function createAdminUser(
   db: Pool,
@@ -20,5 +21,5 @@ export async function listAdminUsers(db: Pool) {
   const res = await db.query(
     'SELECT id, email, role, created_at FROM public.admin_users ORDER BY email'
   );
-  return res.rows;
+  return parseRows(res.rows);
 }

--- a/src/services/creditor.service.ts
+++ b/src/services/creditor.service.ts
@@ -2,6 +2,7 @@ import { Pool, PoolClient } from 'pg';
 import { randomUUID } from 'crypto';
 import { CreditorInput, CreditPaymentInput, PaymentQuery } from '../validators/creditor.validator';
 import { isDateFinalized } from './reconciliation.service';
+import { parseRows, parseRow } from '../utils/parseDb';
 
 export async function createCreditor(db: Pool, tenantId: string, input: CreditorInput): Promise<string> {
   const res = await db.query<{ id: string }>(
@@ -17,7 +18,7 @@ export async function listCreditors(db: Pool, tenantId: string) {
     'SELECT id, party_name, contact_number, address, credit_limit, status, created_at FROM public.creditors WHERE tenant_id = $1 ORDER BY party_name',
     [tenantId]
   );
-  return res.rows;
+  return parseRows(res.rows);
 }
 
 export async function updateCreditor(db: Pool, tenantId: string, id: string, input: CreditorInput) {
@@ -41,7 +42,7 @@ export async function getCreditorById(db: Pool | PoolClient, tenantId: string, i
     'SELECT id, credit_limit, balance FROM public.creditors WHERE id = $1 AND tenant_id = $2',
     [id, tenantId]
   );
-  return res.rows[0];
+  return parseRow(res.rows[0]);
 }
 
 export async function incrementCreditorBalance(db: Pool | PoolClient, tenantId: string, id: string, amount: number) {
@@ -102,5 +103,5 @@ export async function listCreditPayments(db: Pool, tenantId: string, query: Paym
      ORDER BY received_at DESC`,
     params
   );
-  return res.rows;
+  return parseRows(res.rows);
 }

--- a/src/services/delivery.service.ts
+++ b/src/services/delivery.service.ts
@@ -1,6 +1,7 @@
 import { Pool, PoolClient } from 'pg';
 import { randomUUID } from 'crypto';
 import { DeliveryInput, DeliveryQuery } from '../validators/delivery.validator';
+import { parseRows } from '../utils/parseDb';
 
 export async function createFuelDelivery(db: Pool, tenantId: string, input: DeliveryInput): Promise<string> {
   const client = await db.connect();
@@ -52,5 +53,5 @@ export async function listFuelDeliveries(db: Pool, tenantId: string, query: Deli
                FROM ${tenantId}.fuel_deliveries ${where}
                ORDER BY delivery_date DESC`;
   const res = await db.query(sql, params);
-  return res.rows;
+  return parseRows(res.rows);
 }

--- a/src/services/fuelInventory.service.ts
+++ b/src/services/fuelInventory.service.ts
@@ -1,5 +1,6 @@
 import { Pool } from 'pg';
 import { randomUUID } from 'crypto';
+import { parseRows } from '../utils/parseDb';
 
 export interface FuelInventory {
   id: string;
@@ -31,7 +32,7 @@ export async function getFuelInventory(db: Pool, tenantId: string): Promise<Fuel
   
   try {
     const result = await db.query(query);
-    return result.rows;
+    return parseRows(result.rows);
   } catch (error) {
     console.error('Error fetching fuel inventory:', error);
     // If table doesn't exist yet, return empty array

--- a/src/services/fuelPrice.service.ts
+++ b/src/services/fuelPrice.service.ts
@@ -1,6 +1,7 @@
 import { Pool } from 'pg';
 import { randomUUID } from 'crypto';
 import { FuelPriceInput, FuelPriceQuery } from '../validators/fuelPrice.validator';
+import { parseRows } from '../utils/parseDb';
 
 export async function createFuelPrice(db: Pool, tenantId: string, input: FuelPriceInput): Promise<string> {
   const client = await db.connect();
@@ -52,7 +53,7 @@ export async function listFuelPrices(db: Pool, tenantId: string, query: FuelPric
                ${where}
                ORDER BY valid_from DESC`;
   const res = await db.query(sql, params);
-  return res.rows;
+  return parseRows(res.rows);
 }
 
 export async function getPriceAt(db: Pool, tenantId: string, stationId: string, fuelType: string, at: Date): Promise<number | null> {

--- a/src/services/inventory.service.ts
+++ b/src/services/inventory.service.ts
@@ -1,5 +1,6 @@
 import { Pool } from 'pg';
 import { randomUUID } from 'crypto';
+import { parseRows, parseRow } from '../utils/parseDb';
 
 export async function getInventory(db: Pool, tenantId: string, stationId?: string) {
   const stationFilter = stationId ? 'WHERE fi.station_id = $1' : '';
@@ -26,16 +27,18 @@ export async function getInventory(db: Pool, tenantId: string, stationId?: strin
   `;
   
   const result = await db.query(query, params);
-  return result.rows.map(row => ({
-    id: row.id,
-    stationId: row.station_id,
-    stationName: row.station_name,
-    fuelType: row.fuel_type,
-    currentStock: parseFloat(row.current_stock),
-    minimumLevel: parseFloat(row.minimum_level),
-    lastUpdated: row.last_updated,
-    stockStatus: row.stock_status
-  }));
+  return parseRows(
+    result.rows.map(row => ({
+      id: row.id,
+      stationId: row.station_id,
+      stationName: row.station_name,
+      fuelType: row.fuel_type,
+      currentStock: parseFloat(row.current_stock),
+      minimumLevel: parseFloat(row.minimum_level),
+      lastUpdated: row.last_updated,
+      stockStatus: row.stock_status
+    }))
+  );
 }
 
 export async function updateInventory(db: Pool, tenantId: string, stationId: string, fuelType: string, newStock: number) {
@@ -103,16 +106,18 @@ export async function getAlerts(db: Pool, tenantId: string, stationId?: string, 
   `;
   
   const result = await db.query(query, params);
-  return result.rows.map(row => ({
-    id: row.id,
-    stationId: row.station_id,
-    stationName: row.station_name,
-    alertType: row.alert_type,
-    message: row.message,
-    severity: row.severity,
-    isRead: row.is_read,
-    createdAt: row.created_at
-  }));
+  return parseRows(
+    result.rows.map(row => ({
+      id: row.id,
+      stationId: row.station_id,
+      stationName: row.station_name,
+      alertType: row.alert_type,
+      message: row.message,
+      severity: row.severity,
+      isRead: row.is_read,
+      createdAt: row.created_at
+    }))
+  );
 }
 
 export async function markAlertRead(db: Pool, tenantId: string, alertId: string): Promise<boolean> {

--- a/src/services/nozzle.service.ts
+++ b/src/services/nozzle.service.ts
@@ -1,6 +1,7 @@
 import { Pool } from 'pg';
 import { randomUUID } from 'crypto';
 import { beforeCreateNozzle } from '../middleware/planEnforcement';
+import { parseRows } from '../utils/parseDb';
 
 export async function createNozzle(db: Pool, tenantId: string, pumpId: string, nozzleNumber: number, fuelType: string): Promise<string> {
   const client = await db.connect();
@@ -53,7 +54,7 @@ export async function listNozzles(db: Pool, tenantId: string, pumpId?: string) {
     `SELECT id, pump_id, nozzle_number, fuel_type, status, created_at FROM public.nozzles ${where} ${where ? 'AND tenant_id = $2' : 'WHERE tenant_id = $1'} ORDER BY nozzle_number`,
     params
   );
-  return res.rows;
+  return parseRows(res.rows);
 }
 
 export async function deleteNozzle(db: Pool, tenantId: string, nozzleId: string) {

--- a/src/services/nozzleReading.service.ts
+++ b/src/services/nozzleReading.service.ts
@@ -4,6 +4,7 @@ import { getPriceAtTimestamp } from '../utils/priceUtils';
 import { NozzleReadingInput, ReadingQuery } from '../validators/nozzleReading.validator';
 import { getCreditorById, incrementCreditorBalance } from './creditor.service';
 import { isDayFinalized } from './reconciliation.service';
+import { parseRows } from '../utils/parseDb';
 
 export async function createNozzleReading(
   db: Pool,
@@ -113,5 +114,5 @@ export async function listNozzleReadings(
     ${where}
     ORDER BY nr.recorded_at DESC`;
   const res = await db.query(sql, params);
-  return res.rows;
+  return parseRows(res.rows);
 }

--- a/src/services/pump.service.ts
+++ b/src/services/pump.service.ts
@@ -1,6 +1,7 @@
 import { Pool } from 'pg';
 import { randomUUID } from 'crypto';
 import { beforeCreatePump } from '../middleware/planEnforcement';
+import { parseRows } from '../utils/parseDb';
 
 export async function createPump(db: Pool, tenantId: string, stationId: string, label: string, serialNumber?: string): Promise<string> {
   const client = await db.connect();
@@ -27,10 +28,12 @@ export async function listPumps(db: Pool, tenantId: string, stationId?: string) 
      FROM public.pumps p WHERE p.tenant_id = $${stationId ? 2 : 1} ${where ? 'AND ' + where : ''} ORDER BY p.label`,
     params
   );
-  return res.rows.map(row => ({
-    ...row,
-    nozzleCount: parseInt(row.nozzle_count)
-  }));
+  return parseRows(
+    res.rows.map(row => ({
+      ...row,
+      nozzleCount: parseInt(row.nozzle_count)
+    }))
+  );
 }
 
 export async function deletePump(db: Pool, tenantId: string, pumpId: string) {

--- a/src/services/reconciliation.service.ts
+++ b/src/services/reconciliation.service.ts
@@ -1,5 +1,6 @@
 import { Pool, PoolClient } from 'pg';
 import { randomUUID } from 'crypto';
+import { parseRows, parseRow } from '../utils/parseDb';
 
 export interface ReconciliationTotals {
   totalSales: number;
@@ -112,7 +113,7 @@ export async function getReconciliation(
      FROM public.day_reconciliations WHERE station_id = $1 AND date = $2 AND tenant_id = $3`,
     [stationId, date, tenantId]
   );
-  return res.rows[0];
+  return parseRow(res.rows[0]);
 }
 
 export async function listReconciliations(
@@ -130,5 +131,5 @@ export async function listReconciliations(
   }
   query += ' ORDER BY date DESC';
   const res = await db.query(query, params);
-  return res.rows;
+  return parseRows(res.rows);
 }

--- a/src/services/settings.service.ts
+++ b/src/services/settings.service.ts
@@ -1,12 +1,13 @@
 import { Pool } from 'pg';
 import { SettingsInput } from '../validators/settings.validator';
+import { parseRow } from '../utils/parseDb';
 
 export async function getTenantSettings(db: Pool, tenantId: string) {
   const res = await db.query(
     'SELECT receipt_template, fuel_rounding, branding_logo_url FROM public.tenant_settings WHERE tenant_id = $1',
     [tenantId]
   );
-  return res.rows[0] || {};
+  return parseRow(res.rows[0] || {});
 }
 
 export async function upsertTenantSettings(db: Pool, tenantId: string, input: SettingsInput) {

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import bcrypt from 'bcrypt';
 import { UserRole } from '../constants/auth';
 import { beforeCreateUser } from '../middleware/planEnforcement';
+import { parseRows } from '../utils/parseDb';
 
 export async function createUser(
   db: Pool,
@@ -31,5 +32,5 @@ export async function listUsers(db: Pool, tenantId: string) {
     'SELECT id, email, name, role, created_at FROM public.users WHERE tenant_id = $1 ORDER BY email',
     [tenantId]
   );
-  return res.rows;
+  return parseRows(res.rows);
 }

--- a/src/utils/parseDb.ts
+++ b/src/utils/parseDb.ts
@@ -1,0 +1,25 @@
+export function parseValue(val: any): any {
+  if (val === null || val === undefined) return val;
+  if (typeof val === 'string') {
+    if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(val) && !isNaN(Date.parse(val))) {
+      const d = new Date(val);
+      if (!isNaN(d.getTime())) return d;
+    }
+    const n = Number(val);
+    if (!isNaN(n)) return n;
+  }
+  return val;
+}
+
+export function parseRow<T extends Record<string, any>>(row: T): T {
+  if (!row) return row;
+  const parsed: any = {};
+  for (const [k, v] of Object.entries(row)) {
+    parsed[k] = parseValue(v);
+  }
+  return parsed;
+}
+
+export function parseRows<T>(rows: T[]): T[] {
+  return rows.map(r => parseRow(r));
+}


### PR DESCRIPTION
## Summary
- add parseDb utility for converting number and date strings
- apply helper across service layer so all endpoints return typed values
- document new fix in changelog, phase summary and implementation index
- record step details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fd350f9448320bc7a34044d222953