### PR TITLE
Fix parseRows generic constraint

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2140,3 +2140,12 @@ Each entry is tied to a step from the implementation index.
 * `src/utils/parseDb.ts`
 * `src/services/*`
 * `docs/STEP_fix_20250918.md`
+
+## [Fix - 2025-09-19] – Generic constraint for parseRows
+
+### 🟥 Fixes
+* Added an explicit `extends Record<string, any>` constraint to `parseRows` to satisfy TypeScript type checks.
+
+### Files
+* `src/utils/parseDb.ts`
+* `docs/STEP_fix_20250919.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -161,3 +161,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-09-16 | Nozzle reading service wiring | ✅ Done | `src/controllers/nozzleReading.controller.ts` | `docs/STEP_fix_20250916.md` |
 | fix | 2025-09-17 | Sales listing numeric values | ✅ Done | `src/services/sales.service.ts` | `docs/STEP_fix_20250917.md` |
 | fix | 2025-09-18 | Numeric and date parsing | ✅ Done | `src/utils/parseDb.ts`, `src/services/*` | `docs/STEP_fix_20250918.md` |
+| fix | 2025-09-19 | TypeScript generic constraint | ✅ Done | `src/utils/parseDb.ts` | `docs/STEP_fix_20250919.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -923,3 +923,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Introduced a shared parser so all service methods return numbers and `Date` objects rather than strings.
+
+### 🛠️ Fix 2025-09-19 – TypeScript generic constraint
+**Status:** ✅ Done
+**Files:** `src/utils/parseDb.ts`, `docs/STEP_fix_20250919.md`
+
+**Overview:**
+* Added an explicit record constraint to `parseRows` so TypeScript build passes.

--- a/docs/STEP_fix_20250919.md
+++ b/docs/STEP_fix_20250919.md
@@ -1,0 +1,16 @@
+# STEP_fix_20250919.md — TypeScript generic constraint
+
+## Project Context Summary
+The `parseDb` helper introduced in the previous step added `parseRows<T>` without a type constraint. TypeScript compilation failed when building the project because `parseRows` invoked `parseRow`, which expects an object.
+
+## Steps Already Implemented
+All fixes through `STEP_fix_20250918.md`.
+
+## What Was Done Now
+- Added `extends Record<string, any>` to the `parseRows` generic in `src/utils/parseDb.ts`.
+- Verified that `npm run build` now completes without errors.
+
+## Required Documentation Updates
+- Add changelog entry.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Update `PHASE_2_SUMMARY.md`.

--- a/docs/STEP_fix_20250919_COMMAND.md
+++ b/docs/STEP_fix_20250919_COMMAND.md
@@ -1,0 +1,17 @@
+# STEP_fix_20250919_COMMAND.md
+
+## Project Context Summary
+The TypeScript build is failing in `parseRows` because the generic type lacks a constraint.
+
+## Steps Already Implemented
+See `IMPLEMENTATION_INDEX.md` through `STEP_fix_20250918.md`.
+
+## What to Build Now
+- Constrain `parseRows` with `extends Record<string, any>`.
+- Rebuild to confirm compilation succeeds.
+- Update documentation: changelog, implementation index, phase summary.
+
+## Required Documentation Updates
+- Append fix entry to `CHANGELOG.md`.
+- Mark fix done in `PHASE_2_SUMMARY.md`.
+- Add row to `IMPLEMENTATION_INDEX.md`.

--- a/src/utils/parseDb.ts
+++ b/src/utils/parseDb.ts
@@ -20,6 +20,6 @@ export function parseRow<T extends Record<string, any>>(row: T): T {
   return parsed;
 }
 
-export function parseRows<T>(rows: T[]): T[] {
+export function parseRows<T extends Record<string, any>>(rows: T[]): T[] {
   return rows.map(r => parseRow(r));
 }


### PR DESCRIPTION
## Summary
- constrain `parseRows` to operate on objects
- document TypeScript compile fix

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fd8dc47448320bef6026e8e5d8f67