### PR TITLE
Implement automated alert rules

### DIFF
--- a/docs/BUSINESS_RULES.md
+++ b/docs/BUSINESS_RULES.md
@@ -139,6 +139,18 @@ authenticateJWT → requireRole(['manager']) → checkStationAccess → route ha
 
 All enforced via FK constraints within the active tenant schema.
 
+
+## 🚨 Alert Generation Rules
+| Rule | Description |
+| --- | --- |
+| **No Reading in 24h** | Triggered when a nozzle has not submitted any readings for over 24 hours. |
+| **Missing Fuel Price** | Active nozzle lacks a current fuel price entry. |
+| **Credit Near Limit** | Creditor balance reaches 90% of credit limit. |
+| **Station Inactive** | No activity for 48h or pump maintenance older than 7 days. |
+| **Reading Discrepancy** | Successive reading jump exceeds 20% of previous value. |
+| **Missing Cash Report** | Daily cash report not submitted. |
+
+Alerts are inserted automatically via `alertRules.service.ts`.
 ---
 
 ## 📎 Cross-Reference Index

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2265,3 +2265,14 @@ Each entry is tied to a step from the implementation index.
 * `src/routes/alerts.route.ts`
 * `docs/openapi.yaml`
 * `docs/STEP_2_41_COMMAND.md`
+
+## [Feature - 2025-09-28] – Scheduled alert checks
+
+### 🟩 Features
+* Automated services evaluate missing readings, prices and reports.
+* Alerts raised for creditor limits, inactivity and reading anomalies.
+
+### Files
+* `src/services/alertRules.service.ts`
+* `docs/BUSINESS_RULES.md`
+* `docs/STEP_2_42_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -170,3 +170,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 2     | 2.39 | Fuel price validation endpoints | ✅ Done | `src/services/fuelPriceValidation.service.ts`, `src/controllers/fuelPrice.controller.ts`, `src/routes/fuelPrice.route.ts`, `docs/openapi.yaml` | `docs/STEP_2_39_COMMAND.md` |
 | 2     | 2.40 | Nozzle reading creation validation | ✅ Done | `src/services/nozzleReading.service.ts`, `src/controllers/nozzleReading.controller.ts`, `src/routes/nozzleReading.route.ts`, `docs/openapi.yaml`, `src/docs/swagger.ts` | `docs/STEP_2_40_COMMAND.md` |
 | 2     | 2.41 | Alert creation & summary endpoints | ✅ Done | `src/services/alert.service.ts`, `src/controllers/alerts.controller.ts`, `src/routes/alerts.route.ts`, `docs/openapi.yaml` | `docs/STEP_2_41_COMMAND.md` |
+| 2     | 2.42 | Scheduled alert checks | ✅ Done | `src/services/alertRules.service.ts`, `docs/BUSINESS_RULES.md` | `docs/STEP_2_42_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -989,3 +989,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Added API to create alerts and fetch unread counts grouped by severity.
+
+### 🛠️ Step 2.42 – Automated alert rules
+**Status:** ✅ Done
+**Files:** `src/services/alertRules.service.ts`, `docs/BUSINESS_RULES.md`
+
+**Overview:**
+* Added service functions that generate alerts for missing readings, prices, credit limits, inactivity and cash reports.

--- a/docs/STEP_2_42_COMMAND.md
+++ b/docs/STEP_2_42_COMMAND.md
@@ -1,0 +1,31 @@
+# STEP_2_42_COMMAND.md — Automated alert rules
+
+## Project Context Summary
+FuelSync Hub provides an alerts system for notifications. Manual alert endpoints exist but there are no automated checks to raise common issues.
+
+## Steps Already Implemented
+Backend phase completed through **Step 2.41** which added alert creation and summary endpoints.
+
+## What to Build Now
+- Create `src/services/alertRules.service.ts` containing functions to evaluate:
+  - No readings in 24+ hours.
+  - Active nozzle without fuel price.
+  - Creditors exceeding 90% of credit limit.
+  - Station inactivity or pump maintenance overdue.
+  - Large discrepancies between successive readings.
+  - Missing cash reports per shift.
+  Each function should insert alerts via `alert.service.ts`.
+- Document these behaviours in `docs/BUSINESS_RULES.md`.
+- Update changelog, phase summary and implementation index.
+
+## Files To Update
+- `src/services/alertRules.service.ts`
+- `docs/BUSINESS_RULES.md`
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+
+## Required Documentation Updates
+- Add feature entry in `CHANGELOG.md`.
+- Mark step done in `PHASE_2_SUMMARY.md`.
+- Append row in `IMPLEMENTATION_INDEX.md`.

--- a/src/services/alertRules.service.ts
+++ b/src/services/alertRules.service.ts
@@ -1,0 +1,195 @@
+import prisma from '../utils/prisma';
+import { Prisma } from '@prisma/client';
+import { createAlert } from './alert.service';
+
+/**
+ * Generate alerts when no readings have been received for a nozzle in 24 hours.
+ */
+export async function checkNoReadings24h(tenantId: string) {
+  const query = Prisma.sql`
+    SELECT n.id AS nozzle_id, p.station_id
+      FROM "nozzles" n
+      JOIN "pumps" p ON p.id = n.pump_id
+      LEFT JOIN LATERAL (
+        SELECT recorded_at
+          FROM "nozzle_readings" nr
+         WHERE nr.nozzle_id = n.id
+           AND nr.tenant_id = ${tenantId}
+         ORDER BY recorded_at DESC
+         LIMIT 1
+      ) r ON TRUE
+     WHERE n.tenant_id = ${tenantId}
+       AND n.status = 'active'
+       AND (r.recorded_at IS NULL OR r.recorded_at < NOW() - INTERVAL '24 hours');`;
+
+  const rows = await prisma.$queryRaw<{ nozzle_id: string; station_id: string }[]>(query);
+  for (const row of rows) {
+    await createAlert(
+      tenantId,
+      row.station_id,
+      'no_readings_24h',
+      `No readings for nozzle ${row.nozzle_id} in the last 24h`,
+      'warning'
+    );
+  }
+}
+
+/**
+ * Alert when an active nozzle lacks a current fuel price.
+ */
+export async function checkNozzlePriceMissing(tenantId: string) {
+  const query = Prisma.sql`
+    SELECT n.id AS nozzle_id, p.station_id, n.fuel_type
+      FROM "nozzles" n
+      JOIN "pumps" p ON p.id = n.pump_id
+      LEFT JOIN LATERAL (
+        SELECT 1
+          FROM "fuel_prices" fp
+         WHERE fp.station_id = p.station_id
+           AND fp.fuel_type = n.fuel_type
+           AND fp.tenant_id = ${tenantId}
+           AND fp.valid_from <= NOW()
+           AND (fp.effective_to IS NULL OR fp.effective_to > NOW())
+         LIMIT 1
+      ) price ON TRUE
+     WHERE n.tenant_id = ${tenantId}
+       AND n.status = 'active'
+       AND price IS NULL;`;
+
+  const rows = await prisma.$queryRaw<{ nozzle_id: string; station_id: string; fuel_type: string }[]>(query);
+  for (const row of rows) {
+    await createAlert(
+      tenantId,
+      row.station_id,
+      'missing_price',
+      `No current price for ${row.fuel_type} on nozzle ${row.nozzle_id}`,
+      'warning'
+    );
+  }
+}
+
+/**
+ * Alert when a creditor balance exceeds 90% of their credit limit.
+ */
+export async function checkCreditorsNearLimit(tenantId: string) {
+  const query = Prisma.sql`
+    SELECT id, station_id, party_name
+      FROM "creditors"
+     WHERE tenant_id = ${tenantId}
+       AND status = 'active'
+       AND credit_limit > 0
+       AND balance >= credit_limit * 0.9;`;
+  const rows = await prisma.$queryRaw<{ id: string; station_id: string | null; party_name: string }[]>(query);
+  for (const row of rows) {
+    await createAlert(
+      tenantId,
+      row.station_id,
+      'credit_near_limit',
+      `${row.party_name} is over 90% of credit limit`,
+      'warning'
+    );
+  }
+}
+
+/**
+ * Alert when a station shows no activity or pumps stuck in maintenance.
+ */
+export async function checkStationInactivity(tenantId: string) {
+  const inactiveQuery = Prisma.sql`
+    SELECT st.id
+      FROM "stations" st
+      LEFT JOIN LATERAL (
+        SELECT MAX(nr.recorded_at) AS last_read
+          FROM "nozzle_readings" nr
+          JOIN "nozzles" n ON nr.nozzle_id = n.id
+          JOIN "pumps" p ON n.pump_id = p.id
+         WHERE p.station_id = st.id
+           AND nr.tenant_id = ${tenantId}
+      ) r ON TRUE
+     WHERE st.tenant_id = ${tenantId}
+       AND (r.last_read IS NULL OR r.last_read < NOW() - INTERVAL '48 hours');`;
+  const stations = await prisma.$queryRaw<{ id: string }[]>(inactiveQuery);
+  for (const row of stations) {
+    await createAlert(tenantId, row.id, 'station_inactive', 'Station inactive for 48h', 'warning');
+  }
+
+  const pumpQuery = Prisma.sql`
+    SELECT id, station_id
+      FROM "pumps"
+     WHERE tenant_id = ${tenantId}
+       AND status = 'maintenance'
+       AND updated_at < NOW() - INTERVAL '7 days';`;
+  const pumps = await prisma.$queryRaw<{ id: string; station_id: string }[]>(pumpQuery);
+  for (const p of pumps) {
+    await createAlert(
+      tenantId,
+      p.station_id,
+      'maintenance_overdue',
+      `Pump ${p.id} in maintenance for over 7 days`,
+      'warning'
+    );
+  }
+}
+
+/**
+ * Detect large jumps between successive nozzle readings.
+ */
+export async function checkReadingDiscrepancies(tenantId: string) {
+  const query = Prisma.sql`
+    WITH last_read AS (
+      SELECT nr.nozzle_id,
+             p.station_id,
+             nr.reading,
+             LAG(nr.reading) OVER (PARTITION BY nr.nozzle_id ORDER BY nr.recorded_at) AS prev_read,
+             ROW_NUMBER() OVER (PARTITION BY nr.nozzle_id ORDER BY nr.recorded_at DESC) AS rn
+        FROM "nozzle_readings" nr
+        JOIN "nozzles" n ON nr.nozzle_id = n.id
+        JOIN "pumps" p ON n.pump_id = p.id
+       WHERE nr.tenant_id = ${tenantId}
+    )
+    SELECT nozzle_id, station_id, reading - prev_read AS delta, prev_read
+      FROM last_read
+     WHERE rn = 1
+       AND prev_read IS NOT NULL
+       AND (reading - prev_read) > prev_read * 0.2;`;
+  const rows = await prisma.$queryRaw<{ nozzle_id: string; station_id: string; delta: number }[]>(query);
+  for (const row of rows) {
+    await createAlert(
+      tenantId,
+      row.station_id,
+      'reading_discrepancy',
+      `Large jump (${row.delta}) detected for nozzle ${row.nozzle_id}`,
+      'warning'
+    );
+  }
+}
+
+/**
+ * Alert when a station lacks a cash report for today.
+ */
+export async function checkMissingCashReports(tenantId: string) {
+  const query = Prisma.sql`
+    SELECT st.id
+      FROM "stations" st
+     WHERE st.tenant_id = ${tenantId}
+       AND NOT EXISTS (
+         SELECT 1 FROM "cash_reports" cr
+          WHERE cr.station_id = st.id
+            AND cr.tenant_id = ${tenantId}
+            AND cr.date = CURRENT_DATE
+       );`;
+  const rows = await prisma.$queryRaw<{ id: string }[]>(query);
+  for (const row of rows) {
+    await createAlert(tenantId, row.id, 'missing_cash_report', 'No cash report submitted today', 'warning');
+  }
+}
+
+/** Run all alert checks sequentially. */
+export async function runAllAlertRules(tenantId: string) {
+  await checkNoReadings24h(tenantId);
+  await checkNozzlePriceMissing(tenantId);
+  await checkCreditorsNearLimit(tenantId);
+  await checkStationInactivity(tenantId);
+  await checkReadingDiscrepancies(tenantId);
+  await checkMissingCashReports(tenantId);
+}


### PR DESCRIPTION
## Summary
- add alertRules service to generate alerts for missing readings, prices and other conditions
- document alert generation rules in BUSINESS_RULES
- log new feature in the changelog
- record the step in phase summary and implementation index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ff9ecb8688320bc1d5b720a448e23