### PR TITLE
Add SuperAdmin tenant settings API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2300,3 +2300,19 @@ Each entry is tied to a step from the implementation index.
 * `docs/journeys/MANAGER.md`
 * `docs/journeys/ATTENDANT.md`
 * `docs/STEP_2_44_COMMAND.md`
+
+## [Backend - Step 2.45] – SuperAdmin Tenant Settings
+
+### 🟩 Features
+* Added `tenant_settings_kv` table for per-tenant key-value settings.
+* SuperAdmin APIs to list, read and update tenant settings.
+* Default settings inserted on tenant creation.
+
+### Files
+* `migrations/schema/008_create_tenant_settings_kv.sql`
+* `src/services/settingsService.ts`
+* `src/services/tenant.service.ts`
+* `src/controllers/adminSettings.controller.ts`
+* `src/routes/adminApi.router.ts`
+* `docs/openapi.yaml`
+* `docs/STEP_2_45_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -173,3 +173,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 2     | 2.42 | Scheduled alert checks | ✅ Done | `src/services/alertRules.service.ts`, `docs/BUSINESS_RULES.md` | `docs/STEP_2_42_COMMAND.md` |
 | 2     | 2.43 | Price checks on nozzle readings | ✅ Done | `src/utils/priceUtils.ts`, `src/services/nozzleReading.service.ts`, `tests/sales.service.test.ts` | `docs/STEP_2_43_COMMAND.md` |
 | 2     | 2.44 | Role journey documentation | ✅ Done | `docs/journeys/*` | `docs/STEP_2_44_COMMAND.md` |
+| 2     | 2.45 | SuperAdmin tenant settings | ✅ Done | `migrations/schema/008_create_tenant_settings_kv.sql`, `src/services/settingsService.ts`, `src/services/tenant.service.ts`, `src/controllers/adminSettings.controller.ts`, `src/routes/adminApi.router.ts` | `docs/STEP_2_45_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1011,3 +1011,12 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Added dedicated API journey guides for SUPERADMIN, OWNER, MANAGER and ATTENDANT roles. These documents map login flows, endpoints and DB touch points for QA and future-proofing.
+
+### 🛠️ Step 2.45 – SuperAdmin tenant settings
+**Status:** ✅ Done
+**Files:** `migrations/schema/008_create_tenant_settings_kv.sql`, `src/services/settingsService.ts`, `src/services/tenant.service.ts`, `src/controllers/adminSettings.controller.ts`, `src/routes/adminApi.router.ts`
+
+**Overview:**
+* Introduced `tenant_settings_kv` table to store feature flags and preferences per tenant.
+* Default records are seeded on tenant creation.
+* New SuperAdmin endpoints allow viewing and updating these settings.

--- a/docs/STEP_2_45_COMMAND.md
+++ b/docs/STEP_2_45_COMMAND.md
@@ -1,0 +1,39 @@
+# STEP_2_45_COMMAND.md — SuperAdmin Tenant Settings
+
+## Project Context Summary
+FuelSync Hub now runs on a unified public schema with tenant data keyed by `tenant_id`. SuperAdmin APIs exist for managing tenants, plans and users but there is no way to toggle per-tenant feature flags. We need a simple key-value settings store controlled only by SuperAdmins.
+
+## Steps Already Implemented
+Backend phase is completed through **Step 2.44** which added role journey documentation. All admin routes reside under `/api/v1/admin` and require a JWT with the `superadmin` role.
+
+## What to Build Now
+1. Add a new table `public.tenant_settings_kv` for arbitrary tenant settings.
+2. Seed default settings when a tenant is created.
+3. Implement service `settingsService.ts` with `getAllSettings`, `getSetting` and `updateSetting` functions.
+4. Expose SuperAdmin routes:
+   - `GET /api/v1/admin/tenants/:tenantId/settings`
+   - `GET /api/v1/admin/tenants/:tenantId/settings/:key`
+   - `PUT /api/v1/admin/tenants/:tenantId/settings/:key` `{ value: string }`
+5. Update documentation files and changelog.
+
+## Files to Update
+- `migrations/schema/008_create_tenant_settings_kv.sql` (new)
+- `src/services/settingsService.ts` (new)
+- `src/services/tenant.service.ts`
+- `src/controllers/adminSettings.controller.ts` (new)
+- `src/routes/adminApi.router.ts`
+- `docs/openapi.yaml`
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+
+## Acceptance Criteria
+- SuperAdmins can view and update settings for any tenant.
+- Default settings are inserted on tenant creation.
+- Changelog and phase summary mention Step 2.45.
+- Implementation index lists Step 2.45 with file references.
+
+## Next Step
+```
+Codex, begin execution of STEP_2_45_COMMAND.md
+```

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1248,6 +1248,39 @@ paths:
           application/json:
             schema:
               type: object
+
+  /api/v1/admin/tenants/{tenantId}/settings:
+    get:
+      summary: List tenant settings
+      responses:
+        '200':
+          $ref: '#/components/responses/Success'
+        default:
+          $ref: '#/components/responses/Error'
+  /api/v1/admin/tenants/{tenantId}/settings/{key}:
+    get:
+      summary: Get tenant setting
+      responses:
+        '200':
+          $ref: '#/components/responses/Success'
+        default:
+          $ref: '#/components/responses/Error'
+    put:
+      summary: Update tenant setting
+      responses:
+        '200':
+          $ref: '#/components/responses/Success'
+        default:
+          $ref: '#/components/responses/Error'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                value:
+                  type: string
   /api/v1/analytics/dashboard:
     get:
       summary: Tenant dashboard metrics

--- a/migrations/schema/008_create_tenant_settings_kv.sql
+++ b/migrations/schema/008_create_tenant_settings_kv.sql
@@ -1,0 +1,20 @@
+-- Migration: 008_create_tenant_settings_kv
+-- Description: Key-value settings per tenant managed by SuperAdmin
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.tenant_settings_kv (
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  value TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_settings_kv_tenant ON public.tenant_settings_kv(tenant_id);
+
+INSERT INTO public.schema_migrations (version, description)
+VALUES ('008', 'Create tenant_settings_kv table')
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/src/controllers/adminSettings.controller.ts
+++ b/src/controllers/adminSettings.controller.ts
@@ -1,0 +1,46 @@
+import { Request, Response } from 'express';
+import { Pool } from 'pg';
+import { errorResponse } from '../utils/errorResponse';
+import { successResponse } from '../utils/successResponse';
+import { getAllSettings, getSetting, updateSetting } from '../services/settingsService';
+
+export function createAdminSettingsHandlers(db: Pool) {
+  return {
+    list: async (req: Request, res: Response) => {
+      const tenantId = req.params.tenantId;
+      const { rows } = await db.query('SELECT id FROM public.tenants WHERE id = $1', [tenantId]);
+      if (rows.length === 0) {
+        return errorResponse(res, 404, 'Tenant not found');
+      }
+      const settings = await getAllSettings(db, tenantId);
+      return successResponse(res, { settings });
+    },
+    get: async (req: Request, res: Response) => {
+      const tenantId = req.params.tenantId;
+      const key = req.params.key;
+      const { rows } = await db.query('SELECT id FROM public.tenants WHERE id = $1', [tenantId]);
+      if (rows.length === 0) {
+        return errorResponse(res, 404, 'Tenant not found');
+      }
+      const setting = await getSetting(db, tenantId, key);
+      if (!setting) {
+        return errorResponse(res, 404, 'Setting not found');
+      }
+      return successResponse(res, { setting });
+    },
+    update: async (req: Request, res: Response) => {
+      const tenantId = req.params.tenantId;
+      const key = req.params.key;
+      const value = req.body?.value;
+      if (typeof value !== 'string') {
+        return errorResponse(res, 400, 'Invalid value');
+      }
+      const { rows } = await db.query('SELECT id FROM public.tenants WHERE id = $1', [tenantId]);
+      if (rows.length === 0) {
+        return errorResponse(res, 404, 'Tenant not found');
+      }
+      await updateSetting(db, tenantId, key, value);
+      return successResponse(res, { status: 'updated' });
+    }
+  };
+}

--- a/src/routes/adminApi.router.ts
+++ b/src/routes/adminApi.router.ts
@@ -4,10 +4,12 @@ import { authenticateJWT } from '../middlewares/authenticateJWT';
 import { requireRole } from '../middlewares/requireRole';
 import { UserRole } from '../constants/auth';
 import { createAdminApiHandlers } from '../controllers/admin.controller';
+import { createAdminSettingsHandlers } from '../controllers/adminSettings.controller';
 
 export function createAdminApiRouter(db: Pool) {
   const router = Router();
   const handlers = createAdminApiHandlers(db);
+  const settingsHandlers = createAdminSettingsHandlers(db);
   
   // Middleware to ensure SuperAdmin role
   const requireSuperAdmin = requireRole([UserRole.SuperAdmin]);
@@ -36,6 +38,11 @@ export function createAdminApiRouter(db: Pool) {
   router.put('/users/:id', authenticateJWT, requireSuperAdmin, handlers.updateAdminUser);
   router.delete('/users/:id', authenticateJWT, requireSuperAdmin, handlers.deleteAdminUser);
   router.post('/users/:id/reset-password', authenticateJWT, requireSuperAdmin, handlers.resetAdminPassword);
-  
+
+  // Tenant Settings
+  router.get('/tenants/:tenantId/settings', authenticateJWT, requireSuperAdmin, settingsHandlers.list);
+  router.get('/tenants/:tenantId/settings/:key', authenticateJWT, requireSuperAdmin, settingsHandlers.get);
+  router.put('/tenants/:tenantId/settings/:key', authenticateJWT, requireSuperAdmin, settingsHandlers.update);
+
   return router;
 }

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -1,0 +1,53 @@
+import { Pool } from 'pg';
+
+export interface Setting {
+  key: string;
+  value: string;
+  updatedAt: string;
+}
+
+export async function getAllSettings(db: Pool, tenantId: string): Promise<Setting[]> {
+  const res = await db.query(
+    'SELECT key, value, updated_at FROM public.tenant_settings_kv WHERE tenant_id = $1 ORDER BY key',
+    [tenantId]
+  );
+  return res.rows.map(r => ({ key: r.key, value: r.value, updatedAt: r.updated_at }));
+}
+
+export async function getSetting(db: Pool, tenantId: string, key: string): Promise<Setting | null> {
+  const res = await db.query(
+    'SELECT key, value, updated_at FROM public.tenant_settings_kv WHERE tenant_id = $1 AND key = $2',
+    [tenantId, key]
+  );
+  if (res.rows.length === 0) return null;
+  const row = res.rows[0];
+  return { key: row.key, value: row.value, updatedAt: row.updated_at };
+}
+
+export async function updateSetting(db: Pool, tenantId: string, key: string, value: string): Promise<void> {
+  await db.query(
+    `INSERT INTO public.tenant_settings_kv (tenant_id, key, value)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (tenant_id, key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()`,
+    [tenantId, key, value]
+  );
+}
+
+export async function setDefaultSettings(client: Pool | import('pg').Client, tenantId: string): Promise<void> {
+  const defaults = [
+    { key: 'branding.theme_color', value: '#FF9900' },
+    { key: 'fuel.low_stock_threshold', value: '1000' },
+    { key: 'alerts.enabled', value: 'true' },
+    { key: 'features.auto_sales_generation', value: 'true' },
+    { key: 'features.allow_export', value: 'true' }
+  ];
+
+  for (const row of defaults) {
+    await client.query(
+      `INSERT INTO public.tenant_settings_kv (tenant_id, key, value)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (tenant_id, key) DO NOTHING`,
+      [tenantId, row.key, row.value]
+    );
+  }
+}

--- a/src/services/tenant.service.ts
+++ b/src/services/tenant.service.ts
@@ -2,6 +2,7 @@ import { Pool } from 'pg';
 import { randomUUID } from 'crypto';
 import { slugify } from '../utils/slugify';
 import { parseRow, parseRows } from '../utils/parseDb';
+import { setDefaultSettings } from "./settingsService";
 
 export interface TenantInput {
   name: string;
@@ -87,6 +88,8 @@ export async function createTenant(db: Pool, input: TenantInput): Promise<Tenant
       'INSERT INTO public.users (id, tenant_id, email, password_hash, name, role, updated_at) VALUES ($1,$2,$3,$4,$5,$6,NOW())',
       [randomUUID(), tenant.id, attendantEmail, attendantHash, `${input.name} Attendant`, 'attendant']
     );
+
+    await setDefaultSettings(client, tenant.id);
 
     await client.query('COMMIT');
 


### PR DESCRIPTION
## Summary
- create key-value table `tenant_settings_kv`
- seed default settings on tenant creation
- add service utilities for listing/updating settings
- expose SuperAdmin settings endpoints
- document new endpoints and update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860cf695f18832088e8dd88c5543597