### PR TITLE
Fix seed admin timestamp defaults

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2403,3 +2403,12 @@ Each entry is tied to a step from the implementation index.
 * `scripts/setup-azure-schema.js`
 * `docs/AZURE_DEV_SETUP.md`
 * `docs/STEP_1_26_COMMAND.md`
+
+## [Fix - 2025-10-06] – Seed admin timestamps
+
+### 🟥 Fixes
+* Seed admin user now sets `created_at` and `updated_at` explicitly to `NOW()`.
+
+### Files
+* `migrations/schema/003_unified_schema.sql`
+* `docs/STEP_fix_20251006.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -182,3 +182,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-10-03 | SSL in migration script | ✅ Done | `scripts/migrate.js` | `docs/STEP_fix_20251003.md` |
 | fix | 2025-10-04 | UUID defaults in migrations | ✅ Done | `migrations/schema/001_initial_schema.sql`, `migrations/schema/003_unified_schema.sql`, `migrations/schema/004_complete_unified_schema.sql`, `migrations/schema/005_master_unified_schema.sql` | `docs/STEP_fix_20251004.md` |
 | fix | 2025-10-05 | PoolClient default settings | ✅ Done | `src/services/settingsService.ts` | `docs/STEP_fix_20251005.md` |
+| fix | 2025-10-06 | Admin user timestamp defaults | ✅ Done | `migrations/schema/003_unified_schema.sql` | `docs/STEP_fix_20251006.md` |

--- a/docs/PHASE_1_SUMMARY.md
+++ b/docs/PHASE_1_SUMMARY.md
@@ -592,3 +592,14 @@ Each step includes:
 
 **Validations Performed:**
 * `node scripts/setup-azure-schema.js` detects Codex environment and skips without error.
+
+### 🛠 Fix 2025-10-06 – Seed admin timestamps
+
+**Status:** ✅ Done
+**Files:** `migrations/schema/003_unified_schema.sql`
+
+**Overview:**
+* Seed admin INSERT now specifies `created_at` and `updated_at` with `NOW()` so timestamps are always present.
+
+**Validations Performed:**
+* `node scripts/migrate.js up` completes through migration 003 (requires database).

--- a/docs/STEP_fix_20251006.md
+++ b/docs/STEP_fix_20251006.md
@@ -1,0 +1,12 @@
+# STEP_fix_20251006.md — Seed admin timestamps
+
+## Project Context Summary
+Migration `003_unified_schema.sql` seeds the initial super admin user but omitted explicit `created_at` and `updated_at` values. Some environments failed to apply defaults, resulting in NULL timestamps.
+
+## What Was Done Now
+- Updated the seed admin INSERT to specify `created_at` and `updated_at` with `NOW()`.
+
+## Required Documentation Updates
+- Changelog entry under Fixes
+- Implementation index row
+- Phase 1 summary bullet

--- a/docs/STEP_fix_20251006_COMMAND.md
+++ b/docs/STEP_fix_20251006_COMMAND.md
@@ -1,0 +1,16 @@
+# STEP_fix_20251006_COMMAND.md
+
+## Project Context Summary
+The unified schema migration seeds a default super admin account. The insert did not set `created_at` or `updated_at`, leaving these values to rely on column defaults. Some environments ignore defaults during INSERT with explicit column lists, so timestamps could be null.
+
+## Steps Already Implemented
+Fixes through `STEP_fix_20251005.md`.
+
+## What to Build Now
+- Update `migrations/schema/003_unified_schema.sql` to supply `created_at` and `updated_at` in the seed admin INSERT.
+- Document the fix in changelog, implementation index and phase summary.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_1_SUMMARY.md`

--- a/migrations/schema/003_unified_schema.sql
+++ b/migrations/schema/003_unified_schema.sql
@@ -339,8 +339,15 @@ COMMENT ON TABLE public.validation_issues IS 'Records data validation errors for
 CREATE INDEX IF NOT EXISTS idx_validation_issues_tenant ON public.validation_issues(tenant_id);
 
 -- Seed single super admin
-INSERT INTO public.admin_users (id, email, password_hash, role)
-VALUES (gen_random_uuid(), 'admin@example.com', '$2b$10$replace_with_hash', 'superadmin')
+INSERT INTO public.admin_users
+  (id, email, password_hash, role, created_at, updated_at)
+VALUES
+  (gen_random_uuid(),
+   'admin@example.com',
+   '$2b$10$replace_with_hash',
+   'superadmin',
+   NOW(),
+   NOW())
 ON CONFLICT (email) DO NOTHING;
 
 -- Record migration


### PR DESCRIPTION
## Summary
- ensure the super admin seed statement sets `created_at` and `updated_at`
- document the timestamp fix

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68629d4b94f88320b9defc0e2400c8f0