### PR TITLE
Fix fuel inventory seed timestamp

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2471,3 +2471,12 @@ Each entry is tied to a step from the implementation index.
 ### Files
 * `scripts/apply-tenant-settings-kv-azure.js`
 * `docs/STEP_fix_20251012.md`
+
+## [Fix - 2025-11-01] – Fuel inventory updated_at column
+
+### 🟥 Fixes
+* Added `updated_at` column in `createFuelInventoryTable` so seeding works.
+
+### Files
+* `src/services/fuelInventory.service.ts`
+* `docs/STEP_fix_20251101.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -189,3 +189,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-10-10 | Azure tenant_settings_kv migration | ✅ Done | `scripts/apply-tenant-settings-kv-azure.js`, `scripts/setup-azure-db.js`, `package.json` | `docs/STEP_fix_20251010.md` |
 | fix | 2025-10-11 | Azure README instructions | ✅ Done | `README.md` | `docs/STEP_fix_20251011.md` |
 | fix | 2025-10-12 | Azure migration helper syntax | ✅ Done | `scripts/apply-tenant-settings-kv-azure.js` | `docs/STEP_fix_20251012.md` |
+| fix | 2025-11-01 | Fuel inventory updated_at column | ✅ Done | `src/services/fuelInventory.service.ts` | `docs/STEP_fix_20251101.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1042,3 +1042,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * setDefaultSettings now accepts a `PoolClient` so tenant creation compiles without type errors.
 
+
+### 🛠️ Fix 2025-11-01 – Fuel inventory updated_at column
+**Status:** ✅ Done
+**Files:** `src/services/fuelInventory.service.ts`, `docs/STEP_fix_20251101.md`
+
+**Overview:**
+* Added `updated_at` timestamp to the tenant `fuel_inventory` table to align with seed logic.

--- a/docs/STEP_fix_20251101.md
+++ b/docs/STEP_fix_20251101.md
@@ -1,0 +1,15 @@
+# STEP_fix_20251101.md — Fuel inventory timestamp fix
+
+## Project Context Summary
+Seeding fuel inventory records failed because `createFuelInventoryTable` did not
+include an `updated_at` column even though the seed script inserts into it.
+
+## What Was Done Now
+- Added `updated_at TIMESTAMPTZ` to the table definition in
+  `src/services/fuelInventory.service.ts` so runtime table creation matches the
+  unified schema and seed logic.
+
+## Required Documentation Updates
+- Changelog entry under Fixes
+- Implementation index row
+- Phase 2 summary bullet

--- a/docs/STEP_fix_20251101_COMMAND.md
+++ b/docs/STEP_fix_20251101_COMMAND.md
@@ -1,0 +1,22 @@
+# STEP_fix_20251101_COMMAND.md
+
+## Project Context Summary
+Recent seed logic for tenant fuel inventory inserts an `updated_at` timestamp.
+However the helper `createFuelInventoryTable` only defines a `last_updated`
+column which causes inserts to fail when setting `updated_at`.
+
+## Steps Already Implemented
+- Unified schema migrations include both `last_updated` and `updated_at` columns
+  on `fuel_inventory`.
+- Inventory and delivery services rely on these timestamps when updating stock.
+
+## What to Build Now
+Add an `updated_at` column to the table created by
+`createFuelInventoryTable` so the seed function matches the schema.
+Update docs accordingly.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- Create `docs/STEP_fix_20251101.md`

--- a/src/services/fuelInventory.service.ts
+++ b/src/services/fuelInventory.service.ts
@@ -49,6 +49,7 @@ export async function createFuelInventoryTable(db: Pool, tenantId: string): Prom
       current_volume DECIMAL(10, 2) NOT NULL DEFAULT 0,
       capacity DECIMAL(10, 2) NOT NULL,
       last_updated TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+      updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
       created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
       UNIQUE(station_id, fuel_type)
     )


### PR DESCRIPTION
## Summary
- add updated_at column when creating fuel inventory table so seed data works
- document fix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863b36ffe048320944f406f9b258358