### PR TITLE
Fix successResponse argument order

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2580,3 +2580,12 @@ Each entry is tied to a step from the implementation index.
 * `docs/FRONTEND_REFERENCE_GUIDE.md`
 * `docs/PHASE_3_SUMMARY.md`
 * `docs/STEP_fix_20251109.md`
+## [Fix - 2025-11-10] – successResponse parameter alignment
+
+### 🟥 Fixes
+* Updated create endpoints to pass the HTTP status code as the fourth argument of `successResponse`.
+* Compilation no longer fails due to type mismatch.
+
+### Files
+* `src/controllers/*.ts` updated
+* `docs/STEP_2_49_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -193,6 +193,7 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-11-02 | Delivery & inventory schema enums | ✅ Done | `docs/openapi.yaml`, `frontend/docs/openapi-v1.yaml`, `src/docs/swagger.ts` | `docs/STEP_fix_20251102.md` |
 | 2     | 2.47 | Response wrapper & analytics endpoints | ✅ Done | see docs/STEP_2_47_COMMAND.md | `PHASE_2_SUMMARY.md#step-2.47` |
 | 2     | 2.48 | Script guide & cleanup | ✅ Done | `docs/SCRIPTS_GUIDE.md` | `docs/STEP_2_48_COMMAND.md` |
+| 2     | 2.49 | successResponse parameter alignment | ✅ Done | `src/controllers/...` | `PHASE_2_SUMMARY.md#step-2.49` |
 | fix | 2025-11-05 | Frontend guide & spec path | ✅ Done | `docs/FRONTEND_REFERENCE_GUIDE.md`, `docs/PHASE_3_SUMMARY.md`, `frontend/docs/api-diff.md` | `docs/STEP_fix_20251105.md` |
 | fix | 2025-11-06 | Column update process doc | ✅ Done | `docs/FRONTEND_REFERENCE_GUIDE.md` | `docs/STEP_fix_20251106.md` |
 | fix | 2025-11-07 | Column workflow relocation | ✅ Done | `docs/DATABASE_MANAGEMENT.md`, `docs/FRONTEND_REFERENCE_GUIDE.md`, `docs/PHASE_3_SUMMARY.md` | `docs/STEP_fix_20251107.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1075,3 +1075,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 * Deleted obsolete testing utilities.
 * README files link to the new guide.
 
+
+### 🛠️ Step 2.49 – successResponse parameter alignment
+**Status:** ✅ Done
+**Files:** `docs/STEP_2_49_COMMAND.md`, various controllers
+
+**Overview:**
+* Updated create endpoints to pass the HTTP status code as the fourth argument of `successResponse`.

--- a/docs/STEP_2_49_COMMAND.md
+++ b/docs/STEP_2_49_COMMAND.md
@@ -1,0 +1,37 @@
+# STEP_2_49_COMMAND.md — successResponse parameter alignment
+
+## Project Context Summary
+Some create endpoints still call `successResponse` with the HTTP status as the third
+argument. Since Step 2.47 standardised `successResponse(res, data, message?, status = 200)`,
+passing the status in the third slot leads to TypeScript errors during build.
+
+## Steps Already Implemented
+Backend work is complete through **Step 2.48** which documented scripts and cleaned up utilities.
+
+## What to Build Now
+- Update all controller calls that pass a number as the third parameter to `successResponse`.
+  They should pass `undefined` as the message and specify the status in the fourth position.
+- No other functional changes.
+
+## Files to Update
+- `src/controllers/admin.controller.ts`
+- `src/controllers/adminUser.controller.ts`
+- `src/controllers/alerts.controller.ts`
+- `src/controllers/attendant.controller.ts`
+- `src/controllers/creditor.controller.ts`
+- `src/controllers/delivery.controller.ts`
+- `src/controllers/fuelPrice.controller.ts`
+- `src/controllers/nozzle.controller.ts`
+- `src/controllers/nozzleReading.controller.ts`
+- `src/controllers/pump.controller.ts`
+- `src/controllers/reconciliation.controller.ts`
+- `src/controllers/reports.controller.ts`
+- `src/controllers/station.controller.ts`
+- `src/controllers/tenant.controller.ts`
+- Update docs: `docs/CHANGELOG.md`, `docs/PHASE_2_SUMMARY.md`, `docs/IMPLEMENTATION_INDEX.md`.
+- `docs/STEP_2_49_COMMAND.md` (this file)
+
+## Required Documentation Updates
+- Add changelog entry under Fixes.
+- Mark step done in `PHASE_2_SUMMARY.md`.
+- Append row in `IMPLEMENTATION_INDEX.md`.

--- a/src/controllers/admin.controller.ts
+++ b/src/controllers/admin.controller.ts
@@ -24,7 +24,7 @@ export function createAdminApiHandlers(db: Pool) {
           ownerEmail,
           ownerPassword
         });
-        successResponse(res, tenant, 201);
+        successResponse(res, tenant, undefined, 201);
       } catch (err: any) {
         return errorResponse(res, 500, err.message);
       }
@@ -95,7 +95,7 @@ export function createAdminApiHandlers(db: Pool) {
           priceYearly,
           features
         });
-        successResponse(res, plan, 201);
+        successResponse(res, plan, undefined, 201);
       } catch (err: any) {
         return errorResponse(res, 500, err.message);
       }
@@ -162,7 +162,7 @@ export function createAdminApiHandlers(db: Pool) {
         }
         
         const adminUser = await adminService.createAdminUser(db, { email, name, password, role });
-        successResponse(res, adminUser, 201);
+        successResponse(res, adminUser, undefined, 201);
       } catch (err: any) {
         return errorResponse(res, 500, err.message);
       }

--- a/src/controllers/adminUser.controller.ts
+++ b/src/controllers/adminUser.controller.ts
@@ -11,7 +11,7 @@ export function createAdminUserHandlers(db: Pool) {
       try {
         const { email, password } = validateAdminUser(req.body);
         await createAdminUser(db, email, password);
-        successResponse(res, { status: 'ok' }, 201);
+        successResponse(res, { status: 'ok' }, undefined, 201);
       } catch (err: any) {
         return errorResponse(res, 400, err.message);
       }

--- a/src/controllers/alerts.controller.ts
+++ b/src/controllers/alerts.controller.ts
@@ -67,7 +67,7 @@ export function createAlertsHandlers(db: Pool) {
           message,
           severity
         );
-        successResponse(res, alert, 201);
+        successResponse(res, alert, undefined, 201);
       } catch (err: any) {
         return errorResponse(res, 500, err.message);
       }

--- a/src/controllers/attendant.controller.ts
+++ b/src/controllers/attendant.controller.ts
@@ -69,7 +69,7 @@ export function createAttendantHandlers(db: Pool) {
           Number(cashAmount || 0),
           Number(creditAmount || 0)
         );
-        successResponse(res, { id }, 201);
+        successResponse(res, { id }, undefined, 201);
       } catch (err: any) {
         return errorResponse(res, 400, err.message);
       }

--- a/src/controllers/creditor.controller.ts
+++ b/src/controllers/creditor.controller.ts
@@ -31,7 +31,7 @@ export function createCreditorHandlers(db: Pool) {
         }
         const data = validateCreateCreditor(req.body);
         const id = await createCreditor(db, tenantId, data);
-        successResponse(res, { id }, 201);
+        successResponse(res, { id }, undefined, 201);
       } catch (err: any) {
         if (err instanceof ServiceError) {
           return errorResponse(res, err.code, err.message);
@@ -114,7 +114,7 @@ export function createCreditorHandlers(db: Pool) {
         }
         const data = validateCreatePayment(req.body);
         const id = await createCreditPayment(db, user.tenantId, data, user.userId);
-        successResponse(res, { id }, 201);
+        successResponse(res, { id }, undefined, 201);
       } catch (err: any) {
         if (err instanceof ServiceError) {
           return errorResponse(res, err.code, err.message);

--- a/src/controllers/delivery.controller.ts
+++ b/src/controllers/delivery.controller.ts
@@ -15,7 +15,7 @@ export function createDeliveryHandlers(db: Pool) {
         }
         const data = validateCreateDelivery(req.body);
         const id = await createFuelDelivery(db, tenantId, data);
-        successResponse(res, { id }, 201);
+        successResponse(res, { id }, undefined, 201);
       } catch (err: any) {
         return errorResponse(res, 400, err.message);
       }

--- a/src/controllers/fuelPrice.controller.ts
+++ b/src/controllers/fuelPrice.controller.ts
@@ -29,7 +29,7 @@ export function createFuelPriceHandlers(db: Pool) {
           },
           select: { id: true }
         });
-        successResponse(res, { id: price.id }, 201);
+        successResponse(res, { id: price.id }, undefined, 201);
       } catch (err: any) {
         return errorResponse(res, 400, err.message);
       }

--- a/src/controllers/nozzle.controller.ts
+++ b/src/controllers/nozzle.controller.ts
@@ -23,7 +23,7 @@ export function createNozzleHandlers(db: Pool) {
           },
           select: { id: true }
         });
-        successResponse(res, { id: nozzle.id }, 201);
+        successResponse(res, { id: nozzle.id }, undefined, 201);
       } catch (err: any) {
         return errorResponse(res, 400, err.message);
       }

--- a/src/controllers/nozzleReading.controller.ts
+++ b/src/controllers/nozzleReading.controller.ts
@@ -15,7 +15,7 @@ export function createNozzleReadingHandlers(db: Pool) {
         }
         const data = validateCreateNozzleReading(req.body);
         const id = await createNozzleReading(db, user.tenantId, data, user.userId);
-        successResponse(res, { id }, 201);
+        successResponse(res, { id }, undefined, 201);
       } catch (err: any) {
         return errorResponse(res, 400, err.message);
       }

--- a/src/controllers/pump.controller.ts
+++ b/src/controllers/pump.controller.ts
@@ -23,7 +23,7 @@ export function createPumpHandlers(db: Pool) {
           },
           select: { id: true }
         });
-        successResponse(res, { id: pump.id }, 201);
+        successResponse(res, { id: pump.id }, undefined, 201);
       } catch (err: any) {
         return errorResponse(res, 400, err.message);
       }

--- a/src/controllers/reconciliation.controller.ts
+++ b/src/controllers/reconciliation.controller.ts
@@ -25,7 +25,7 @@ export function createReconciliationHandlers(db: Pool) {
           return errorResponse(res, 400, 'Invalid reconciliationDate');
         }
         const summary = await runReconciliation(db, user.tenantId, stationId, date);
-        successResponse(res, { summary }, 201);
+        successResponse(res, { summary }, undefined, 201);
       } catch (err: any) {
         return errorResponse(res, 400, err.message);
       }

--- a/src/controllers/reports.controller.ts
+++ b/src/controllers/reports.controller.ts
@@ -189,7 +189,7 @@ export function createReportsHandlers(db: Pool) {
           `INSERT INTO public.report_schedules (tenant_id, station_id, type, frequency) VALUES ($1,$2,$3,$4) RETURNING id`,
           [tenantId, stationId || null, type, frequency]
         );
-        successResponse(res, { id: result.rows[0].id }, 201);
+        successResponse(res, { id: result.rows[0].id }, undefined, 201);
       } catch (err: any) {
         return errorResponse(res, 500, err.message);
       }

--- a/src/controllers/station.controller.ts
+++ b/src/controllers/station.controller.ts
@@ -23,7 +23,7 @@ export function createStationHandlers(db: Pool) {
           },
           select: { id: true }
         });
-        successResponse(res, { id: station.id }, 201);
+        successResponse(res, { id: station.id }, undefined, 201);
       } catch (err: any) {
         return errorResponse(res, 400, err.message);
       }

--- a/src/controllers/tenant.controller.ts
+++ b/src/controllers/tenant.controller.ts
@@ -50,7 +50,7 @@ export function createTenantHandlers(db: Pool) {
             password: result.owner.password,
             name: result.owner.name
           }
-        }, 201);
+        }, undefined, 201);
       } catch (err: any) {
         console.error('Error creating tenant:', err);
         return errorResponse(res, 400, err.message);


### PR DESCRIPTION
## Summary
- fix create endpoints to send status as fourth argument to `successResponse`
- document fix and update implementation index and phase summary
- record step instructions in `STEP_2_49_COMMAND.md`

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68640d28c9508320b1bd04b037987472