### PR TITLE
Add setup status endpoint

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2589,3 +2589,15 @@ Each entry is tied to a step from the implementation index.
 ### Files
 * `src/controllers/*.ts` updated
 * `docs/STEP_2_49_COMMAND.md`
+## [Feature - 2025-11-11] – Setup status API
+
+### 🟢 Features
+* Added `/api/v1/setup-status` endpoint to check onboarding completion without extra tables.
+
+### Files
+* `src/services/setupStatus.service.ts`
+* `src/controllers/setupStatus.controller.ts`
+* `src/routes/setupStatus.route.ts`
+* `src/app.ts`
+* `docs/openapi.yaml`
+* `docs/STEP_2_50_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -194,6 +194,7 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 2     | 2.47 | Response wrapper & analytics endpoints | ✅ Done | see docs/STEP_2_47_COMMAND.md | `PHASE_2_SUMMARY.md#step-2.47` |
 | 2     | 2.48 | Script guide & cleanup | ✅ Done | `docs/SCRIPTS_GUIDE.md` | `docs/STEP_2_48_COMMAND.md` |
 | 2     | 2.49 | successResponse parameter alignment | ✅ Done | `src/controllers/...` | `PHASE_2_SUMMARY.md#step-2.49` |
+| 2     | 2.50 | Setup status API | ✅ Done | `src/services/setupStatus.service.ts`, `src/controllers/setupStatus.controller.ts`, `src/routes/setupStatus.route.ts` | `PHASE_2_SUMMARY.md#step-2.50` |
 | fix | 2025-11-05 | Frontend guide & spec path | ✅ Done | `docs/FRONTEND_REFERENCE_GUIDE.md`, `docs/PHASE_3_SUMMARY.md`, `frontend/docs/api-diff.md` | `docs/STEP_fix_20251105.md` |
 | fix | 2025-11-06 | Column update process doc | ✅ Done | `docs/FRONTEND_REFERENCE_GUIDE.md` | `docs/STEP_fix_20251106.md` |
 | fix | 2025-11-07 | Column workflow relocation | ✅ Done | `docs/DATABASE_MANAGEMENT.md`, `docs/FRONTEND_REFERENCE_GUIDE.md`, `docs/PHASE_3_SUMMARY.md` | `docs/STEP_fix_20251107.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1082,3 +1082,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Updated create endpoints to pass the HTTP status code as the fourth argument of `successResponse`.
+
+### 🛠️ Step 2.50 – Setup status API
+**Status:** ✅ Done
+**Files:** `src/services/setupStatus.service.ts`, `src/controllers/setupStatus.controller.ts`, `src/routes/setupStatus.route.ts`, `src/app.ts`, `docs/openapi.yaml`, `docs/STEP_2_50_COMMAND.md`
+
+**Overview:**
+* Added `/setup-status` endpoint to compute onboarding progress via entity counts.
+* Service checks stations, pumps, nozzles and fuel prices for the current tenant.

--- a/docs/STEP_2_50_COMMAND.md
+++ b/docs/STEP_2_50_COMMAND.md
@@ -1,0 +1,27 @@
+# STEP_2_50_COMMAND.md — Setup status API
+
+## Project Context Summary
+The FuelSync Hub backend is a Node/Express API with PostgreSQL. Backend work is complete through **Step 2.49** which aligned `successResponse` parameters. The application uses schema-per-tenant tables and JWT-based tenant context.
+
+## Steps Already Implemented
+* All core CRUD endpoints for stations, pumps, nozzles and fuel prices exist.
+* Phase 2 documentation up to step 2.49 is complete.
+
+## What to Build Now
+Implement a new endpoint `GET /api/v1/setup-status` that returns whether a tenant has completed the minimum setup. This should be computed on the fly using entity counts; no new tables.
+
+## Files to Update
+* `src/services/setupStatus.service.ts` (new) — calculate counts and return `SetupStatusDTO`.
+* `src/controllers/setupStatus.controller.ts` (new) — expose a handler using the service.
+* `src/routes/setupStatus.route.ts` (new) — route definition.
+* `src/app.ts` — mount the new router.
+* `docs/openapi.yaml` — document the endpoint.
+* `docs/PHASE_2_SUMMARY.md`
+* `docs/IMPLEMENTATION_INDEX.md`
+* `docs/CHANGELOG.md`
+* `docs/STEP_2_50_COMMAND.md` (this file)
+
+## Required Documentation Updates
+* Add changelog entry under Features.
+* Mark step done in `PHASE_2_SUMMARY.md`.
+* Append row in `IMPLEMENTATION_INDEX.md`.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1432,6 +1432,14 @@ paths:
           application/json:
             schema:
               type: object
+  /api/v1/setup-status:
+    get:
+      summary: Check tenant setup status
+      responses:
+        '200':
+          $ref: '#/components/responses/Success'
+        default:
+          $ref: '#/components/responses/Error'
   /api/v1/stations/compare:
     get:
       summary: Compare station performance

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,6 +24,7 @@ import { createReportsRouter } from './routes/reports.route';
 import { createAnalyticsRouter } from './routes/analytics.route';
 import { createAlertsRouter } from './routes/alerts.route';
 import { createAttendantRouter } from "./routes/attendant.route";
+import { createSetupStatusRouter } from './routes/setupStatus.route';
 import docsRouter from './routes/docs.route';
 import { errorHandler } from './middlewares/errorHandler';
 import { successResponse } from './utils/successResponse';
@@ -188,6 +189,7 @@ export function createApp() {
   app.use(`${API_PREFIX}/inventory`, createInventoryRouter(pool));
   app.use(`${API_PREFIX}/reports`, createReportsRouter(pool));
   app.use(`${API_PREFIX}/analytics`, createAnalyticsRouter(pool));
+  app.use(`${API_PREFIX}`, createSetupStatusRouter(pool));
   app.use(`${API_PREFIX}/attendant`, createAttendantRouter(pool));
 
   app.use('*', (_req, res) => {

--- a/src/controllers/setupStatus.controller.ts
+++ b/src/controllers/setupStatus.controller.ts
@@ -1,0 +1,22 @@
+import { Request, Response } from 'express';
+import { Pool } from 'pg';
+import { getSetupStatus } from '../services/setupStatus.service';
+import { errorResponse } from '../utils/errorResponse';
+import { successResponse } from '../utils/successResponse';
+
+export function createSetupStatusHandlers(db: Pool) {
+  return {
+    status: async (req: Request, res: Response) => {
+      try {
+        const tenantId = req.user?.tenantId;
+        if (!tenantId) {
+          return errorResponse(res, 400, 'Missing tenant context');
+        }
+        const result = await getSetupStatus(db, tenantId);
+        return successResponse(res, result);
+      } catch (err: any) {
+        return errorResponse(res, 400, err.message);
+      }
+    }
+  };
+}

--- a/src/routes/setupStatus.route.ts
+++ b/src/routes/setupStatus.route.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { Pool } from 'pg';
+import { authenticateJWT } from '../middlewares/authenticateJWT';
+import { setTenantContext } from '../middlewares/setTenantContext';
+import { requireRole } from '../middlewares/requireRole';
+import { UserRole } from '../constants/auth';
+import { createSetupStatusHandlers } from '../controllers/setupStatus.controller';
+
+export function createSetupStatusRouter(db: Pool) {
+  const router = Router();
+  const handlers = createSetupStatusHandlers(db);
+
+  router.get('/setup-status', authenticateJWT, setTenantContext, requireRole([UserRole.Owner, UserRole.Manager]), handlers.status);
+
+  return router;
+}

--- a/src/services/setupStatus.service.ts
+++ b/src/services/setupStatus.service.ts
@@ -1,0 +1,31 @@
+import { Pool } from 'pg';
+
+export interface SetupStatusDTO {
+  hasStation: boolean;
+  hasPump: boolean;
+  hasNozzle: boolean;
+  hasFuelPrice: boolean;
+  completed: boolean;
+}
+
+export async function getSetupStatus(db: Pool, tenantId: string): Promise<SetupStatusDTO> {
+  const [stations, pumps, nozzles, prices] = await Promise.all([
+    db.query('SELECT COUNT(*) FROM public.stations WHERE tenant_id = $1', [tenantId]),
+    db.query('SELECT COUNT(*) FROM public.pumps WHERE tenant_id = $1', [tenantId]),
+    db.query('SELECT COUNT(*) FROM public.nozzles WHERE tenant_id = $1', [tenantId]),
+    db.query('SELECT COUNT(*) FROM public.fuel_prices WHERE tenant_id = $1', [tenantId])
+  ]);
+
+  const hasStation = Number(stations.rows[0].count) > 0;
+  const hasPump = Number(pumps.rows[0].count) > 0;
+  const hasNozzle = Number(nozzles.rows[0].count) > 0;
+  const hasFuelPrice = Number(prices.rows[0].count) > 0;
+
+  return {
+    hasStation,
+    hasPump,
+    hasNozzle,
+    hasFuelPrice,
+    completed: hasStation && hasPump && hasNozzle && hasFuelPrice
+  };
+}


### PR DESCRIPTION
## Summary
- implement setupStatus service and controller
- expose `/api/v1/setup-status` route
- document the new endpoint in OpenAPI
- update phase summary, changelog and implementation index

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68641c45f53c83209674cb383aad6e57