### PR TITLE
Add nozzle conflict error handling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2610,3 +2610,16 @@ Each entry is tied to a step from the implementation index.
 ### Files
 * `src/utils/seedHelpers.ts`
 * `docs/STEP_1_17_COMMAND.md`
+
+## [Fix - 2025-11-13] – Duplicate nozzle conflict handling
+
+### 🟥 Fixes
+* `create` handler in `nozzle.controller` now returns **409** when a nozzle number already exists for the pump.
+* OpenAPI spec documents the 409 response.
+* Added unit test for this scenario.
+
+### Files
+* `src/controllers/nozzle.controller.ts`
+* `docs/openapi.yaml`
+* `tests/nozzle.controller.test.ts`
+* `docs/STEP_2_51_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -195,6 +195,7 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 2     | 2.48 | Script guide & cleanup | ✅ Done | `docs/SCRIPTS_GUIDE.md` | `docs/STEP_2_48_COMMAND.md` |
 | 2     | 2.49 | successResponse parameter alignment | ✅ Done | `src/controllers/...` | `PHASE_2_SUMMARY.md#step-2.49` |
 | 2     | 2.50 | Setup status API | ✅ Done | `src/services/setupStatus.service.ts`, `src/controllers/setupStatus.controller.ts`, `src/routes/setupStatus.route.ts` | `PHASE_2_SUMMARY.md#step-2.50` |
+| 2     | 2.51 | Duplicate nozzle conflict handling | ✅ Done | `src/controllers/nozzle.controller.ts`, `docs/openapi.yaml`, `tests/nozzle.controller.test.ts` | `PHASE_2_SUMMARY.md#step-2.51` |
 | fix | 2025-11-05 | Frontend guide & spec path | ✅ Done | `docs/FRONTEND_REFERENCE_GUIDE.md`, `docs/PHASE_3_SUMMARY.md`, `frontend/docs/api-diff.md` | `docs/STEP_fix_20251105.md` |
 | fix | 2025-11-06 | Column update process doc | ✅ Done | `docs/FRONTEND_REFERENCE_GUIDE.md` | `docs/STEP_fix_20251106.md` |
 | fix | 2025-11-07 | Column workflow relocation | ✅ Done | `docs/DATABASE_MANAGEMENT.md`, `docs/FRONTEND_REFERENCE_GUIDE.md`, `docs/PHASE_3_SUMMARY.md` | `docs/STEP_fix_20251107.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1090,3 +1090,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * Added `/setup-status` endpoint to compute onboarding progress via entity counts.
 * Service checks stations, pumps, nozzles and fuel prices for the current tenant.
+
+### 🛠️ Step 2.51 – Duplicate nozzle conflict handling
+**Status:** ✅ Done
+**Files:** `src/controllers/nozzle.controller.ts`, `docs/openapi.yaml`, `tests/nozzle.controller.test.ts`, `docs/STEP_2_51_COMMAND.md`
+
+**Overview:**
+* Creation errors from Prisma with code `P2002` now return status `409` and a clear message.
+* OpenAPI spec lists the 409 response and a unit test verifies the behaviour.

--- a/docs/STEP_2_51_COMMAND.md
+++ b/docs/STEP_2_51_COMMAND.md
@@ -1,0 +1,28 @@
+# STEP_2_51_COMMAND.md — Nozzle duplicate handling
+
+## Project Context Summary
+FuelSync Hub backend exposes CRUD routes for stations, pumps and nozzles. Up through **Step 2.50** the create nozzle endpoint simply returned a generic 400 error on failures. Duplicating a nozzle number for the same pump should surface a conflict.
+
+## Steps Already Implemented
+- successResponse and errorResponse utilities standardised (Step 2.49).
+- Setup status API added in Step 2.50.
+
+## What to Build Now
+- Catch `PrismaClientKnownRequestError` when creating a nozzle and return a 409 response if `err.code === 'P2002'` with message "Nozzle number already exists for this pump.".
+- Add a unit test verifying that duplicates yield status 409.
+- Document the new 409 response in `docs/openapi.yaml` for `POST /api/v1/nozzles`.
+- Update documentation (changelog, phase summary, implementation index).
+
+## Files to Update
+- `src/controllers/nozzle.controller.ts`
+- `docs/openapi.yaml`
+- `tests/nozzle.controller.test.ts` (new)
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_2_51_COMMAND.md` (this file)
+
+## Required Documentation Updates
+- Append changelog entry under Fixes.
+- Mark step done in `PHASE_2_SUMMARY.md`.
+- Add row to `IMPLEMENTATION_INDEX.md`.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -164,6 +164,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Success'
+        '409':
+          $ref: '#/components/responses/Error'
         default:
           $ref: '#/components/responses/Error'
   /api/v1/users/{userId}/change-password:
@@ -298,6 +300,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Success'
+        '409':
+          $ref: '#/components/responses/Error'
         default:
           $ref: '#/components/responses/Error'
   /api/v1/stations/{stationId}/metrics:
@@ -411,6 +415,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Success'
+        '409':
+          $ref: '#/components/responses/Error'
         default:
           $ref: '#/components/responses/Error'
       requestBody:

--- a/src/controllers/nozzle.controller.ts
+++ b/src/controllers/nozzle.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { Pool } from 'pg';
 import prisma from '../utils/prisma';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { validateCreateNozzle } from '../validators/nozzle.validator';
 import { errorResponse } from '../utils/errorResponse';
 import { successResponse } from '../utils/successResponse';
@@ -25,6 +26,16 @@ export function createNozzleHandlers(db: Pool) {
         });
         successResponse(res, { id: nozzle.id }, undefined, 201);
       } catch (err: any) {
+        if (
+          err instanceof PrismaClientKnownRequestError &&
+          err.code === 'P2002'
+        ) {
+          return errorResponse(
+            res,
+            409,
+            'Nozzle number already exists for this pump.'
+          );
+        }
         return errorResponse(res, 400, err.message);
       }
     },

--- a/tests/nozzle.controller.test.ts
+++ b/tests/nozzle.controller.test.ts
@@ -1,0 +1,34 @@
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+import prisma from '../src/utils/prisma';
+import { createNozzleHandlers } from '../src/controllers/nozzle.controller';
+
+jest.mock('../src/utils/prisma', () => ({
+  nozzle: { create: jest.fn() }
+}));
+
+const handlers = createNozzleHandlers({} as any);
+
+const req = {
+  user: { tenantId: 't1' },
+  body: { pumpId: 'p1', nozzleNumber: 1, fuelType: 'petrol' }
+} as any;
+
+const res = {
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis()
+} as any;
+
+describe('nozzle.controller.create', () => {
+  test('returns 409 on duplicate nozzle', async () => {
+    const error = new PrismaClientKnownRequestError('Duplicate', 'P2002', '1');
+    (prisma.nozzle.create as jest.Mock).mockRejectedValueOnce(error);
+
+    await handlers.create(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Nozzle number already exists for this pump.'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- handle Prisma P2002 duplicate errors when creating nozzles
- document 409 response in OpenAPI spec
- record step 2.51 in implementation docs
- add unit test for duplicate nozzle creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68643535a8648320b4f8b7d5a5cae2cf