### PR TITLE
Update pump name handling

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2176,7 +2176,7 @@ paths:
           type: number
     CreatePumpRequest:
       type: object
-      required: [stationId, name, serialNumber]
+      required: [stationId, name]
       properties:
         stationId:
           type: string

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -128,7 +128,7 @@ model Pump {
   id            String   @id @default(uuid())
   tenant_id     String
   station_id    String
-  label         String
+  name          String
   serial_number String?
   status        String   @default("active")
   created_at    DateTime @default(now())
@@ -136,7 +136,7 @@ model Pump {
   station       Station  @relation(fields: [station_id], references: [id], onDelete: Cascade)
   nozzles       Nozzle[]
 
-  @@unique([tenant_id, station_id, label])
+  @@unique([tenant_id, station_id, name])
   @@index([tenant_id])
   @@index([station_id])
   @@map("pumps")

--- a/scripts/seed-data.js
+++ b/scripts/seed-data.js
@@ -147,7 +147,7 @@ async function seedData() {
         id: '00000000-0000-0000-0000-000000000030',
         tenant_id: demoTenant.id,
         station_id: mainStation.id,
-        label: 'Pump 1',
+        name: 'Pump 1',
         serial_number: 'P10001',
         status: 'active'
       }
@@ -160,7 +160,7 @@ async function seedData() {
         id: '00000000-0000-0000-0000-000000000031',
         tenant_id: demoTenant.id,
         station_id: mainStation.id,
-        label: 'Pump 2',
+        name: 'Pump 2',
         serial_number: 'P10002',
         status: 'active'
       }

--- a/src/controllers/pump.controller.ts
+++ b/src/controllers/pump.controller.ts
@@ -18,12 +18,11 @@ export function createPumpHandlers(db: Pool) {
           data: {
             tenant_id: tenantId,
             station_id: data.stationId,
-            label: data.label,
+            name: data.name,
             serial_number: data.serialNumber || null
-          },
-          select: { id: true }
+          }
         });
-        successResponse(res, { id: pump.id }, undefined, 201);
+        successResponse(res, { pump }, undefined, 201);
       } catch (err: any) {
         return errorResponse(res, 400, err.message);
       }
@@ -39,7 +38,7 @@ export function createPumpHandlers(db: Pool) {
           tenant_id: tenantId,
           ...(stationId ? { station_id: stationId } : {})
         },
-        orderBy: { label: 'asc' },
+        orderBy: { name: 'asc' },
         include: { _count: { select: { nozzles: true } } }
       });
       successResponse(res, {
@@ -61,7 +60,7 @@ export function createPumpHandlers(db: Pool) {
         if (!pump) {
           return errorResponse(res, 404, 'Pump not found');
         }
-        successResponse(res, pump);
+        successResponse(res, { pump });
       } catch (err: any) {
         return errorResponse(res, 400, err.message);
       }
@@ -90,17 +89,17 @@ export function createPumpHandlers(db: Pool) {
         if (!tenantId) {
           return errorResponse(res, 400, 'Missing tenant context');
         }
-        const { label, serialNumber } = req.body;
+        const { name, serialNumber } = req.body;
         const updated = await prisma.pump.updateMany({
           where: { id: req.params.id, tenant_id: tenantId },
           data: {
-            ...(label !== undefined ? { label } : {}),
+            ...(name !== undefined ? { name } : {}),
             ...(serialNumber !== undefined ? { serial_number: serialNumber } : {})
           }
         });
         if (!updated.count) return errorResponse(res, 404, 'Pump not found');
         const pump = await prisma.pump.findUnique({ where: { id: req.params.id } });
-        successResponse(res, pump);
+        successResponse(res, { pump });
       } catch (err: any) {
         return errorResponse(res, 400, err.message);
       }

--- a/src/services/attendant.service.ts
+++ b/src/services/attendant.service.ts
@@ -16,11 +16,11 @@ export async function listUserStations(db: Pool, tenantId: string, userId: strin
 
 export async function listUserPumps(db: Pool, tenantId: string, userId: string, stationId: string) {
   const res = await db.query(
-    `SELECT p.id, p.label, p.station_id
+    `SELECT p.id, p.name, p.station_id
        FROM public.pumps p
        JOIN public.user_stations us ON us.station_id = p.station_id
       WHERE us.user_id = $1 AND p.tenant_id = $2 AND p.station_id = $3
-      ORDER BY p.label`,
+      ORDER BY p.name`,
     [userId, tenantId, stationId]
   );
   return parseRows(res.rows);

--- a/src/services/tenant.service.ts
+++ b/src/services/tenant.service.ts
@@ -183,9 +183,9 @@ export async function getTenant(db: Pool, id: string): Promise<any | null> {
   const stations = [] as any[];
   for (const station of parseRows(stationsResult.rows)) {
     const pumpsResult = await db.query(
-      `SELECT p.id, p.label, p.serial_number, p.status,
+      `SELECT p.id, p.name, p.serial_number, p.status,
        (SELECT COUNT(*) FROM public.nozzles n WHERE n.pump_id = p.id) as nozzle_count
-       FROM public.pumps p WHERE p.station_id = $1 ORDER BY p.label`,
+       FROM public.pumps p WHERE p.station_id = $1 ORDER BY p.name`,
       [station.id]
     );
 

--- a/src/validators/pump.validator.ts
+++ b/src/validators/pump.validator.ts
@@ -1,17 +1,16 @@
 export interface PumpInput {
   stationId: string;
-  label: string;
+  name: string;
   serialNumber?: string;
 }
 
 export function validateCreatePump(data: any): PumpInput {
-  const { stationId, name, label, serialNumber } = data || {};
+  const { stationId, name, serialNumber } = data || {};
   if (!stationId || typeof stationId !== 'string') {
     throw new Error('stationId required');
   }
-  const pumpLabel = name || label;
-  if (!pumpLabel || typeof pumpLabel !== 'string') {
-    throw new Error('name or label required');
+  if (!name || typeof name !== 'string') {
+    throw new Error('name required');
   }
-  return { stationId, label: pumpLabel, serialNumber };
+  return { stationId, name, serialNumber };
 }


### PR DESCRIPTION
## Summary
- enforce `name` field when creating pumps
- replace `label` with `name` across services and controllers
- return `{ pump }` objects from pump controller endpoints
- update seed data and Prisma schema
- adjust OpenAPI pump request schema

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686541ee9fd4832090683d7cff2a3fcb