### PR TITLE
Fix pump request schema in OpenAPI

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2623,3 +2623,13 @@ Each entry is tied to a step from the implementation index.
 * `docs/openapi.yaml`
 * `tests/nozzle.controller.test.ts`
 * `docs/STEP_2_51_COMMAND.md`
+
+## [Fix - 2025-11-14] – Pump request schema correction
+
+### 🟥 Fixes
+* Pump creation and update endpoints now reference `CreatePumpRequest`.
+* `CreatePumpRequest` requires `serialNumber` alongside `stationId` and `name`.
+
+### Files
+* `docs/openapi.yaml`
+* `docs/STEP_fix_20251114.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -201,3 +201,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-11-07 | Column workflow relocation | ✅ Done | `docs/DATABASE_MANAGEMENT.md`, `docs/FRONTEND_REFERENCE_GUIDE.md`, `docs/PHASE_3_SUMMARY.md` | `docs/STEP_fix_20251107.md` |
 | fix | 2025-11-08 | Frontend update flow clarifications | ✅ Done | `docs/FRONTEND_REFERENCE_GUIDE.md`, `docs/PHASE_3_SUMMARY.md` | `docs/STEP_fix_20251108.md` |
 | fix | 2025-11-09 | Authoritative frontend flow | ✅ Done | `docs/FRONTEND_REFERENCE_GUIDE.md`, `docs/PHASE_3_SUMMARY.md` | `docs/STEP_fix_20251109.md` |
+| fix | 2025-11-14 | Pump request schema correction | ✅ Done | `docs/openapi.yaml` | `docs/STEP_fix_20251114.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1098,3 +1098,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * Creation errors from Prisma with code `P2002` now return status `409` and a clear message.
 * OpenAPI spec lists the 409 response and a unit test verifies the behaviour.
+
+### 🛠️ Fix 2025-11-14 – Pump request schema correction
+**Status:** ✅ Done
+**Files:** `docs/openapi.yaml`, `docs/STEP_fix_20251114.md`
+
+**Overview:**
+* POST and PUT pump endpoints use the correct `CreatePumpRequest` schema.
+* `CreatePumpRequest` requires `stationId`, `name`, and `serialNumber`.

--- a/docs/STEP_fix_20251114.md
+++ b/docs/STEP_fix_20251114.md
@@ -1,0 +1,14 @@
+# STEP_fix_20251114.md — Pump request schema correction
+
+## Project Context Summary
+The pump endpoints in the OpenAPI spec pointed to `CreateTenantRequest`, causing confusion for API consumers.
+
+## What Was Done Now
+- Updated POST and PUT pump operations to use `CreatePumpRequest`.
+- Marked `serialNumber` as required in `CreatePumpRequest` along with `stationId` and `name`.
+- Documented the update in changelog and phase summary.
+
+## Required Documentation Updates
+- Add changelog entry under Fixes.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_2_SUMMARY.md`.

--- a/docs/STEP_fix_20251114_COMMAND.md
+++ b/docs/STEP_fix_20251114_COMMAND.md
@@ -1,0 +1,19 @@
+# STEP_fix_20251114_COMMAND.md
+
+## Project Context Summary
+Pump endpoints in `docs/openapi.yaml` mistakenly reference `CreateTenantRequest`. The correct schema `CreatePumpRequest` already exists but isn't used.
+
+## Steps Already Implemented
+* Previous steps up to `STEP_2_51_COMMAND.md` updated pump and nozzle documentation.
+
+## What to Build Now
+- Replace `CreateTenantRequest` with `CreatePumpRequest` for POST `/api/v1/pumps` and PUT `/api/v1/pumps/{id}`.
+- Ensure `CreatePumpRequest` requires `stationId`, `name`, and `serialNumber`.
+- Update docs and summaries.
+
+## Required Documentation Updates
+- `docs/openapi.yaml`
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- Create `docs/STEP_fix_20251114.md`

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -359,7 +359,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateTenantRequest'
+              $ref: '#/components/schemas/CreatePumpRequest'
     get:
       summary: List pumps
       description: Returns pumps with `nozzleCount` per pump.
@@ -401,7 +401,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateTenantRequest'
+              $ref: '#/components/schemas/CreatePumpRequest'
     delete:
       summary: Delete pump
       responses:
@@ -2176,7 +2176,7 @@ paths:
           type: number
     CreatePumpRequest:
       type: object
-      required: [stationId, name]
+      required: [stationId, name, serialNumber]
       properties:
         stationId:
           type: string


### PR DESCRIPTION
## Summary
- correct pump POST/PUT request schema to use CreatePumpRequest
- require serialNumber in CreatePumpRequest
- document pump schema fix in changelog and summaries
- add implementation step files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686546b3f0e083209f25e6eedc20929c