### PR TITLE
fix build error in nozzle.validator

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2662,3 +2662,12 @@ Each entry is tied to a step from the implementation index.
 ### Files
 * `src/controllers/nozzle.controller.ts`
 * `docs/STEP_fix_20251117.md`
+
+## [Fix - 2025-11-18] – Nozzle validator type cast
+
+### 🟥 Fixes
+* `validateCreateNozzle` now casts `fuelType` to the union type to satisfy TypeScript.
+
+### Files
+* `src/validators/nozzle.validator.ts`
+* `docs/STEP_fix_20251118.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -205,3 +205,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 2     | 2.52 | Nozzle fuel type validation | ✅ Done | `src/validators/nozzle.validator.ts` | `PHASE_2_SUMMARY.md#step-2.52` |
 | fix | 2025-11-16 | Nozzle request schema cleanup | ✅ Done | `docs/openapi.yaml` | `docs/STEP_fix_20251116_COMMAND.md` |
 | fix | 2025-11-17 | Response object consistency | ✅ Done | `src/controllers/nozzle.controller.ts` | `docs/STEP_fix_20251117.md` |
+| fix | 2025-11-18 | Nozzle validator type cast | ✅ Done | `src/validators/nozzle.validator.ts` | `docs/STEP_fix_20251118.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1127,3 +1127,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * GET handlers return `{ pump }` or `{ nozzle }` within the success response wrapper for consistent API shape.
+
+### 🛠️ Fix 2025-11-18 – Nozzle validator type cast
+**Status:** ✅ Done
+**Files:** `src/validators/nozzle.validator.ts`, `docs/STEP_fix_20251118.md`
+
+**Overview:**
+* Cast `fuelType` to the allowed union type to resolve TypeScript compilation errors.

--- a/docs/STEP_fix_20251118.md
+++ b/docs/STEP_fix_20251118.md
@@ -1,0 +1,14 @@
+# STEP_fix_20251118.md — Nozzle validator type casting
+
+## Project Context Summary
+Running `npm run build` after the pump name refactor produced a type error in `validateCreateNozzle`. The `fuelType` property was typed as `string`, conflicting with the stricter union in `NozzleInput`.
+
+## What Was Done Now
+- Cast `fuelType` to `'petrol' | 'diesel' | 'premium'` when constructing the result object.
+- Verified that `npm run build` completes without errors.
+- Logged this fix in the changelog, phase summary and implementation index.
+
+## Required Documentation Updates
+- Add changelog entry under Fixes.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise fix in `PHASE_2_SUMMARY.md`.

--- a/docs/STEP_fix_20251118_COMMAND.md
+++ b/docs/STEP_fix_20251118_COMMAND.md
@@ -1,0 +1,23 @@
+# STEP_fix_20251118_COMMAND.md — Nozzle validator type casting
+
+## Project Context Summary
+Recent refactoring replaced the pump `label` field with `name`. After regenerating the Prisma client, `tsc` still failed due to a type mismatch in the nozzle validator.
+
+## Steps Already Implemented
+- Response object consistency fix (STEP_fix_20251117.md)
+
+## What to Build Now
+- Cast `fuelType` to the union type in `validateCreateNozzle` so TypeScript accepts the result.
+- Document the fix across changelog, phase summary and implementation index.
+
+## Files to Update
+- `src/validators/nozzle.validator.ts`
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20251118_COMMAND.md` (this file)
+
+## Required Documentation Updates
+- Add changelog entry under Fixes.
+- Append row in `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_2_SUMMARY.md`.

--- a/src/validators/nozzle.validator.ts
+++ b/src/validators/nozzle.validator.ts
@@ -25,7 +25,11 @@ export function validateCreateNozzle(data: any): NozzleInput {
     );
   }
 
-  const result: NozzleInput = { pumpId, nozzleNumber, fuelType };
+  const result: NozzleInput = {
+    pumpId,
+    nozzleNumber,
+    fuelType: fuelType as 'petrol' | 'diesel' | 'premium'
+  };
 
   if (status !== undefined) {
     if (typeof status !== 'string') {


### PR DESCRIPTION
## Summary
- cast `fuelType` to the union type in `validateCreateNozzle`
- document the fix and update implementation index

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686553be59f483209fcf44bcebaae610