### PR TITLE
Update docs for fuel price station relationship

### DIFF
--- a/backend_brain.md
+++ b/backend_brain.md
@@ -286,3 +286,4 @@ The spec now defines request bodies and success/error responses for every endpoi
 4. Address any missing or extra endpoints reported by the script.
 5. Commit code and docs together so the spec and knowledge base never diverge.
 \n### 2025-11-03 Response Wrapper Update\n- Pump listing now includes `nozzleCount` using Prisma \_count.\n- Successful responses are wrapped in `{ success: true, data, message? }`.
+\n### 2025-11-19 Fuel Price Response Enhancement\n- `GET /api/v1/fuel-prices` now includes a `station` object `{ id, name }` for each price entry.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2671,3 +2671,12 @@ Each entry is tied to a step from the implementation index.
 ### Files
 * `src/validators/nozzle.validator.ts`
 * `docs/STEP_fix_20251118.md`
+
+## [Fix - 2025-11-19] – Fuel price response station names
+
+### 🟥 Fixes
+* Fuel price listing now returns associated station `{ id, name }`.
+
+### Files
+* `backend_brain.md`
+* `docs/STEP_fix_20251119.md`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2680,3 +2680,15 @@ Each entry is tied to a step from the implementation index.
 ### Files
 * `backend_brain.md`
 * `docs/STEP_fix_20251119.md`
+
+## [Fix - 2025-11-20] – Fuel price station id in spec
+
+### 🟥 Fixes
+* OpenAPI and complete specs now document station `id` with `name`.
+* Listing endpoint returns station id and name.
+
+### Files
+* `docs/openapi.yaml`
+* `docs/missing/COMPLETE_API_SPEC.yaml`
+* `src/controllers/fuelPrice.controller.ts`
+* `docs/STEP_fix_20251120.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -206,3 +206,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-11-16 | Nozzle request schema cleanup | ✅ Done | `docs/openapi.yaml` | `docs/STEP_fix_20251116_COMMAND.md` |
 | fix | 2025-11-17 | Response object consistency | ✅ Done | `src/controllers/nozzle.controller.ts` | `docs/STEP_fix_20251117.md` |
 | fix | 2025-11-18 | Nozzle validator type cast | ✅ Done | `src/validators/nozzle.validator.ts` | `docs/STEP_fix_20251118.md` |
+| fix | 2025-11-19 | Fuel price station names | ✅ Done | `backend_brain.md` | `docs/STEP_fix_20251119.md` |

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -207,3 +207,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-11-17 | Response object consistency | ✅ Done | `src/controllers/nozzle.controller.ts` | `docs/STEP_fix_20251117.md` |
 | fix | 2025-11-18 | Nozzle validator type cast | ✅ Done | `src/validators/nozzle.validator.ts` | `docs/STEP_fix_20251118.md` |
 | fix | 2025-11-19 | Fuel price station names | ✅ Done | `backend_brain.md` | `docs/STEP_fix_20251119.md` |
+| fix | 2025-11-20 | Fuel price station id in spec | ✅ Done | `docs/openapi.yaml` | `docs/STEP_fix_20251120.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1141,3 +1141,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Fuel price endpoints now include related station details in the response.
+
+### 🛠️ Fix 2025-11-20 – Fuel price station id in spec
+**Status:** ✅ Done
+**Files:** `docs/openapi.yaml`, `src/controllers/fuelPrice.controller.ts`, `docs/STEP_fix_20251120.md`
+
+**Overview:**
+* Fuel price schema now documents `station.id` and listing returns station id with name.

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1134,3 +1134,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Cast `fuelType` to the allowed union type to resolve TypeScript compilation errors.
+
+### 🛠️ Fix 2025-11-19 – Fuel price station names
+**Status:** ✅ Done
+**Files:** `backend_brain.md`, `docs/STEP_fix_20251119.md`
+
+**Overview:**
+* Fuel price endpoints now include related station details in the response.

--- a/docs/STEP_fix_20251119.md
+++ b/docs/STEP_fix_20251119.md
@@ -1,0 +1,13 @@
+# STEP_fix_20251119.md — Fuel price response station names
+
+## Project Context Summary
+Backend and frontend previously returned fuel price entries without station details. The API was updated to include the related station name for each price.
+
+## What Was Done Now
+- Updated `backend_brain.md` to record that `/api/v1/fuel-prices` returns a `station` object with id and name.
+- Documented the change in the changelog, implementation index and phase summary.
+
+## Required Documentation Updates
+- Changelog entry under Fixes.
+- Implementation index row appended.
+- Phase summary updated.

--- a/docs/STEP_fix_20251119_COMMAND.md
+++ b/docs/STEP_fix_20251119_COMMAND.md
@@ -1,0 +1,23 @@
+# STEP_fix_20251119_COMMAND.md — Fuel price response station names
+
+## Project Context Summary
+The backend now returns station names in the fuel prices API response. Documentation must reflect this enhancement.
+
+## Steps Already Implemented
+- Nozzle validator type cast (STEP_fix_20251118.md)
+
+## What to Build Now
+- Update the backend requirements documentation to note that `/api/v1/fuel-prices` includes a `station` object with `id` and `name`.
+- Document the fix in changelog, phase summary and implementation index.
+
+## Files to Update
+- `backend_brain.md`
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20251119_COMMAND.md` (this file)
+
+## Required Documentation Updates
+- Add changelog entry under Fixes.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise fix in `PHASE_2_SUMMARY.md`.

--- a/docs/STEP_fix_20251120.md
+++ b/docs/STEP_fix_20251120.md
@@ -1,0 +1,13 @@
+# STEP_fix_20251120.md — Fuel price spec station id
+
+## Project Context Summary
+The prior fix exposed station names with fuel prices, but the OpenAPI specification only showed `station.name` and the controller didn't include the station relation. This caused contract drift.
+
+## What Was Done Now
+- Added `id` property to the nested `station` object in `openapi.yaml` and the complete spec.
+- Updated `fuelPrice.controller.ts` to include the station relation when listing prices.
+
+## Required Documentation Updates
+- Changelog entry noting spec update and controller fix.
+- Implementation index row.
+- Phase summary update.

--- a/docs/STEP_fix_20251120_COMMAND.md
+++ b/docs/STEP_fix_20251120_COMMAND.md
@@ -1,0 +1,26 @@
+# STEP_fix_20251120_COMMAND.md — Fuel price spec station id
+
+## Project Context Summary
+Fuel price responses now include related station name but the OpenAPI spec only documented the station name. The listing endpoint also didn't include the station relation.
+
+## Steps Already Implemented
+- Fuel price station names doc update (STEP_fix_20251119)
+
+## What to Build Now
+- Update `openapi.yaml` and `docs/missing/COMPLETE_API_SPEC.yaml` so `FuelPrice` includes `station` object with `id` and `name`.
+- Update `src/controllers/fuelPrice.controller.ts` to return station `id` and `name` via Prisma include.
+- Document the fix in changelog, phase summary and implementation index.
+
+## Files to Update
+- `docs/openapi.yaml`
+- `docs/missing/COMPLETE_API_SPEC.yaml`
+- `src/controllers/fuelPrice.controller.ts`
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20251120.md` (summary)
+
+## Required Documentation Updates
+- Changelog entry under Fixes.
+- Implementation index row appended.
+- Phase summary updated.

--- a/docs/missing/COMPLETE_API_SPEC.yaml
+++ b/docs/missing/COMPLETE_API_SPEC.yaml
@@ -112,6 +112,8 @@ components:
         station:
           type: object
           properties:
+            id:
+              type: string
             name:
               type: string
     
@@ -184,6 +186,8 @@ components:
         station:
           type: object
           properties:
+            id:
+              type: string
             name:
               type: string
         nozzle:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2110,6 +2110,8 @@ paths:
         station:
           type: object
           properties:
+            id:
+              type: string
             name:
               type: string
     CreateFuelPriceRequest:

--- a/src/controllers/fuelPrice.controller.ts
+++ b/src/controllers/fuelPrice.controller.ts
@@ -45,7 +45,8 @@ export function createFuelPriceHandlers(db: Pool) {
       if (query.fuelType) filters.fuel_type = query.fuelType;
       const prices = await prisma.fuelPrice.findMany({
         where: filters,
-        orderBy: { valid_from: 'desc' }
+        orderBy: { valid_from: 'desc' },
+        include: { station: { select: { id: true, name: true } } }
       });
       successResponse(res, { prices });
     },


### PR DESCRIPTION
## Summary
- record new fuel price response containing station names
- log change in CHANGELOG, implementation index and phase summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68655a805a008320b0e3432f077cde36