### PR TITLE
Fix API/DB naming drift

### DIFF
--- a/db_brain.md
+++ b/db_brain.md
@@ -16,7 +16,7 @@ This document records the reasoning and structure for migrating FuelSync Hub fro
 | `tenants` | `id`, `name`, `plan_id`, `status`, `created_at`, `updated_at` |
 | `users` | `id`, `tenant_id`, `email`, `password_hash`, `name`, `role`, `created_at`, `updated_at` |
 | `stations` | `id`, `tenant_id`, `name`, `address`, `status`, `created_at`, `updated_at` |
-| `pumps` | `id`, `tenant_id`, `station_id`, `label`, `serial_number`, `status`, `created_at`, `updated_at` |
+| `pumps` | `id`, `tenant_id`, `station_id`, `name`, `serial_number`, `status`, `created_at`, `updated_at` |
 | `nozzles` | `id`, `tenant_id`, `pump_id`, `nozzle_number`, `fuel_type`, `status`, `created_at`, `updated_at` |
 | `fuel_prices` | `id`, `tenant_id`, `station_id`, `fuel_type`, `price`, `cost_price`, `valid_from`, `effective_to`, `created_at`, `updated_at` |
 | `creditors` | `id`, `tenant_id`, `station_id`, `party_name`, `contact_number`, `address`, `credit_limit`, `status`, `created_at`, `updated_at` |

--- a/docs/BACKEND_HIERARCHY_API.md
+++ b/docs/BACKEND_HIERARCHY_API.md
@@ -58,7 +58,7 @@ Authorization: Bearer <super_admin_token>
       "pumps": [
         {
           "id": "pump-uuid-1",
-          "label": "Pump 1",
+          "name": "Pump 1",
           "serialNumber": "P001",
           "status": "active",
           "nozzleCount": 2,
@@ -79,7 +79,7 @@ Authorization: Bearer <super_admin_token>
         },
         {
           "id": "pump-uuid-2",
-          "label": "Pump 2", 
+          "name": "Pump 2",
           "serialNumber": "P002",
           "status": "maintenance",
           "nozzleCount": 1,
@@ -103,7 +103,7 @@ Authorization: Bearer <super_admin_token>
       "pumps": [
         {
           "id": "pump-uuid-3",
-          "label": "Pump 1",
+          "name": "Pump 1",
           "serialNumber": "P003",
           "status": "active",
           "nozzleCount": 2,
@@ -189,11 +189,11 @@ FROM {schema}.stations s
 ORDER BY s.name;
 
 -- Get pumps with nozzle counts
-SELECT p.id, p.label, p.serial_number, p.status,
+SELECT p.id, p.name, p.serial_number, p.status,
        (SELECT COUNT(*) FROM {schema}.nozzles n WHERE n.pump_id = p.id) as nozzle_count
 FROM {schema}.pumps p 
 WHERE p.station_id = $1 
-ORDER BY p.label;
+ORDER BY p.name;
 
 -- Get nozzles for pump
 SELECT id, nozzle_number, fuel_type, status 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2701,3 +2701,16 @@ Each entry is tied to a step from the implementation index.
 ### Files
 * `migrations/schema/009_rename_pumps_label_to_name.sql`
 * `docs/STEP_fix_20251121.md`
+
+## [Fix - 2025-11-22] – Schema naming alignment
+
+### 🟥 Fixes
+* Updated documentation examples to use `pumps.name`.
+* Added Prisma model for `tenant_settings_kv`.
+
+### Files
+* `db_brain.md`
+* `docs/BACKEND_HIERARCHY_API.md`
+* `docs/FRONTEND_NAVIGATION_GUIDE.md`
+* `prisma/schema.prisma`
+* `docs/STEP_fix_20251122.md`

--- a/docs/FRONTEND_NAVIGATION_GUIDE.md
+++ b/docs/FRONTEND_NAVIGATION_GUIDE.md
@@ -129,7 +129,7 @@ function StationDetail({ stationId }) {
         {pumps?.map(pump => (
           <li key={pump.id}>
             <Link to={`/stations/${stationId}/pumps/${pump.id}`}>
-              {pump.label}
+              {pump.name}
             </Link>
           </li>
         ))}

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -209,3 +209,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-11-19 | Fuel price station names | ✅ Done | `backend_brain.md` | `docs/STEP_fix_20251119.md` |
 | fix | 2025-11-20 | Fuel price station id in spec | ✅ Done | `docs/openapi.yaml` | `docs/STEP_fix_20251120.md` |
 | fix | 2025-11-21 | Pump column rename | ✅ Done | `migrations/schema/009_rename_pumps_label_to_name.sql` | `docs/STEP_fix_20251121.md` |
+| fix | 2025-11-22 | Schema naming alignment | ✅ Done | `prisma/schema.prisma`, docs updated | `docs/STEP_fix_20251122.md` |

--- a/docs/PHASE_1_SUMMARY.md
+++ b/docs/PHASE_1_SUMMARY.md
@@ -683,3 +683,14 @@ Each step includes:
 
 **Validations Performed:**
 * Migration applies successfully when run against local database.
+
+### 🛠 Fix 2025-11-22 – Schema naming alignment
+**Status:** ✅ Done
+**Files:** `prisma/schema.prisma`, documentation updates
+
+**Overview:**
+* Added Prisma model for `tenant_settings_kv`.
+* Updated remaining docs to reference `pumps.name`.
+
+**Validations Performed:**
+* `npx prisma format` and `npx prisma generate` executed without errors.

--- a/docs/STEP_fix_20251122.md
+++ b/docs/STEP_fix_20251122.md
@@ -1,0 +1,13 @@
+# STEP_fix_20251122.md — Schema naming alignment
+
+## Project Context Summary
+Documentation examples still referenced the old `pumps.label` column even though the database and API use `name`. The Prisma schema also lacked a model for the `tenant_settings_kv` table used by the settings service.
+
+## What Was Done Now
+- Added `TenantSettingsKv` model to `prisma/schema.prisma` and regenerated Prisma client.
+- Updated `db_brain.md`, `docs/BACKEND_HIERARCHY_API.md` and `docs/FRONTEND_NAVIGATION_GUIDE.md` to use `name` instead of `label`.
+
+## Required Documentation Updates
+- Add changelog entry under Fixes.
+- Update implementation index with this fix step.
+- Mention fix in `PHASE_1_SUMMARY.md`.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,72 +27,73 @@ model Plan {
 }
 
 model Tenant {
-  id                    String              @id @default(uuid())
-  name                  String
-  plan_id               String?
-  status                String              @default("active")
-  created_at            DateTime            @default(now())
-  updated_at            DateTime            @updatedAt
-  deleted_at            DateTime?
-  plan                  Plan?               @relation(fields: [plan_id], references: [id])
-  users                 User[]
-  stations              Station[]
-  tenant_settings       TenantSettings?
-  fuel_inventory        FuelInventory[]
-  alerts                Alert[]
-  fuel_deliveries       FuelDelivery[]
-  credit_payments       CreditPayment[]
-  day_reconciliations   DayReconciliation[]
-  report_schedules      ReportSchedule[]
-  audit_logs            AuditLog[]
-  user_activity_logs    UserActivityLog[]
-  validation_issues     ValidationIssue[]
+  id                  String              @id @default(uuid())
+  name                String
+  plan_id             String?
+  status              String              @default("active")
+  created_at          DateTime            @default(now())
+  updated_at          DateTime            @updatedAt
+  deleted_at          DateTime?
+  plan                Plan?               @relation(fields: [plan_id], references: [id])
+  users               User[]
+  stations            Station[]
+  tenant_settings     TenantSettings?
+  fuel_inventory      FuelInventory[]
+  alerts              Alert[]
+  fuel_deliveries     FuelDelivery[]
+  credit_payments     CreditPayment[]
+  day_reconciliations DayReconciliation[]
+  report_schedules    ReportSchedule[]
+  audit_logs          AuditLog[]
+  user_activity_logs  UserActivityLog[]
+  validation_issues   ValidationIssue[]
+  TenantSettingsKv    TenantSettingsKv[]
 
   @@map("tenants")
 }
 
 model AdminUser {
-  id                   String               @id @default(uuid())
-  email                String               @unique
-  password_hash        String
-  name                 String?
-  role                 String               @default("superadmin")
-  created_at           DateTime             @default(now())
-  updated_at           DateTime             @updatedAt
-  admin_activity_logs  AdminActivityLog[]
+  id                  String             @id @default(uuid())
+  email               String             @unique
+  password_hash       String
+  name                String?
+  role                String             @default("superadmin")
+  created_at          DateTime           @default(now())
+  updated_at          DateTime           @updatedAt
+  admin_activity_logs AdminActivityLog[]
 
   @@map("admin_users")
 }
 
 model AdminActivityLog {
-  id             String     @id @default(uuid())
-  admin_user_id  String?
-  action         String
-  target_type    String?
-  target_id      String?
-  details        Json?
-  created_at     DateTime   @default(now())
-  updated_at     DateTime   @updatedAt
-  admin_user     AdminUser? @relation(fields: [admin_user_id], references: [id], onDelete: Cascade)
+  id            String     @id @default(uuid())
+  admin_user_id String?
+  action        String
+  target_type   String?
+  target_id     String?
+  details       Json?
+  created_at    DateTime   @default(now())
+  updated_at    DateTime   @updatedAt
+  admin_user    AdminUser? @relation(fields: [admin_user_id], references: [id], onDelete: Cascade)
 
   @@map("admin_activity_logs")
 }
 
 // Tenant-specific tables
 model User {
-  id                  String            @id @default(uuid())
-  tenant_id           String
-  email               String
-  password_hash       String
-  name                String
-  role                String
-  created_at          DateTime          @default(now())
-  updated_at          DateTime          @updatedAt
-  tenant              Tenant            @relation(fields: [tenant_id], references: [id], onDelete: Cascade)
-  stations            UserStation[]
-  sales               Sale[]
-  audit_logs          AuditLog[]
-  user_activity_logs  UserActivityLog[]
+  id                 String            @id @default(uuid())
+  tenant_id          String
+  email              String
+  password_hash      String
+  name               String
+  role               String
+  created_at         DateTime          @default(now())
+  updated_at         DateTime          @updatedAt
+  tenant             Tenant            @relation(fields: [tenant_id], references: [id], onDelete: Cascade)
+  stations           UserStation[]
+  sales              Sale[]
+  audit_logs         AuditLog[]
+  user_activity_logs UserActivityLog[]
 
   @@unique([tenant_id, email])
   @@index([tenant_id])
@@ -100,24 +101,24 @@ model User {
 }
 
 model Station {
-  id                    String              @id @default(uuid())
-  tenant_id             String
-  name                  String
-  address               String?
-  status                String              @default("active")
-  created_at            DateTime            @default(now())
-  updated_at            DateTime            @updatedAt
-  tenant                Tenant              @relation(fields: [tenant_id], references: [id], onDelete: Cascade)
-  pumps                 Pump[]
-  users                 UserStation[]
-  creditors             Creditor[]
-  sales                 Sale[]
-  fuel_prices           FuelPrice[]
-  fuel_inventory        FuelInventory[]
-  alerts                Alert[]
-  fuel_deliveries       FuelDelivery[]
-  day_reconciliations   DayReconciliation[]
-  report_schedules      ReportSchedule[]
+  id                  String              @id @default(uuid())
+  tenant_id           String
+  name                String
+  address             String?
+  status              String              @default("active")
+  created_at          DateTime            @default(now())
+  updated_at          DateTime            @updatedAt
+  tenant              Tenant              @relation(fields: [tenant_id], references: [id], onDelete: Cascade)
+  pumps               Pump[]
+  users               UserStation[]
+  creditors           Creditor[]
+  sales               Sale[]
+  fuel_prices         FuelPrice[]
+  fuel_inventory      FuelInventory[]
+  alerts              Alert[]
+  fuel_deliveries     FuelDelivery[]
+  day_reconciliations DayReconciliation[]
+  report_schedules    ReportSchedule[]
 
   @@unique([tenant_id, name])
   @@index([tenant_id])
@@ -143,17 +144,17 @@ model Pump {
 }
 
 model Nozzle {
-  id             String          @id @default(uuid())
-  tenant_id      String
-  pump_id        String
-  nozzle_number  Int
-  fuel_type      String
-  status         String          @default("active")
-  created_at     DateTime        @default(now())
-  updated_at     DateTime        @updatedAt
-  pump           Pump            @relation(fields: [pump_id], references: [id], onDelete: Cascade)
-  readings       NozzleReading[]
-  sales          Sale[]
+  id            String          @id @default(uuid())
+  tenant_id     String
+  pump_id       String
+  nozzle_number Int
+  fuel_type     String
+  status        String          @default("active")
+  created_at    DateTime        @default(now())
+  updated_at    DateTime        @updatedAt
+  pump          Pump            @relation(fields: [pump_id], references: [id], onDelete: Cascade)
+  readings      NozzleReading[]
+  sales         Sale[]
 
   @@unique([tenant_id, pump_id, nozzle_number])
   @@index([tenant_id])
@@ -179,18 +180,18 @@ model FuelPrice {
 }
 
 model Creditor {
-  id             String          @id @default(uuid())
-  tenant_id      String
-  station_id     String?
-  party_name     String
-  contact_number String?
-  address        String?
-  credit_limit   Decimal         @default(0)
-  status         String          @default("active")
-  created_at     DateTime        @default(now())
-  updated_at     DateTime        @updatedAt
-  station        Station?        @relation(fields: [station_id], references: [id], onDelete: Cascade)
-  sales          Sale[]
+  id              String          @id @default(uuid())
+  tenant_id       String
+  station_id      String?
+  party_name      String
+  contact_number  String?
+  address         String?
+  credit_limit    Decimal         @default(0)
+  status          String          @default("active")
+  created_at      DateTime        @default(now())
+  updated_at      DateTime        @updatedAt
+  station         Station?        @relation(fields: [station_id], references: [id], onDelete: Cascade)
+  sales           Sale[]
   credit_payments CreditPayment[]
 
   @@index([tenant_id])
@@ -198,7 +199,7 @@ model Creditor {
 }
 
 model Sale {
-  id             String     @id @default(uuid())
+  id             String         @id @default(uuid())
   tenant_id      String
   nozzle_id      String
   reading_id     String?
@@ -206,20 +207,20 @@ model Sale {
   volume         Decimal
   fuel_type      String
   fuel_price     Decimal
-  cost_price     Decimal    @default(0)
+  cost_price     Decimal        @default(0)
   amount         Decimal
-  profit         Decimal    @default(0)
+  profit         Decimal        @default(0)
   payment_method String
   creditor_id    String?
   created_by     String?
-  status         String     @default("posted")
+  status         String         @default("posted")
   recorded_at    DateTime
-  created_at     DateTime   @default(now())
-  updated_at     DateTime   @updatedAt
-  nozzle         Nozzle     @relation(fields: [nozzle_id], references: [id], onDelete: Cascade)
-  station        Station    @relation(fields: [station_id], references: [id], onDelete: Cascade)
-  creditor       Creditor?  @relation(fields: [creditor_id], references: [id])
-  creator        User?      @relation(fields: [created_by], references: [id])
+  created_at     DateTime       @default(now())
+  updated_at     DateTime       @updatedAt
+  nozzle         Nozzle         @relation(fields: [nozzle_id], references: [id], onDelete: Cascade)
+  station        Station        @relation(fields: [station_id], references: [id], onDelete: Cascade)
+  creditor       Creditor?      @relation(fields: [creditor_id], references: [id])
+  creator        User?          @relation(fields: [created_by], references: [id])
   reading        NozzleReading? @relation(fields: [reading_id], references: [id])
 
   @@index([tenant_id])
@@ -250,6 +251,18 @@ model TenantSettings {
   tenant            Tenant   @relation(fields: [tenant_id], references: [id], onDelete: Cascade)
 
   @@map("tenant_settings")
+}
+
+model TenantSettingsKv {
+  tenant_id  String
+  key        String
+  value      String
+  updated_at DateTime @default(now())
+  tenant     Tenant   @relation(fields: [tenant_id], references: [id], onDelete: Cascade)
+
+  @@id([tenant_id, key])
+  @@index([tenant_id])
+  @@map("tenant_settings_kv")
 }
 
 model FuelInventory {
@@ -320,7 +333,7 @@ model NozzleReading {
 }
 
 model CreditPayment {
-  id               String    @id @default(uuid())
+  id               String   @id @default(uuid())
   tenant_id        String
   creditor_id      String
   amount           Decimal
@@ -328,10 +341,10 @@ model CreditPayment {
   reference_number String?
   notes            String?
   received_at      DateTime
-  created_at       DateTime  @default(now())
-  updated_at       DateTime  @updatedAt
-  tenant           Tenant    @relation(fields: [tenant_id], references: [id], onDelete: Cascade)
-  creditor         Creditor  @relation(fields: [creditor_id], references: [id], onDelete: Cascade)
+  created_at       DateTime @default(now())
+  updated_at       DateTime @updatedAt
+  tenant           Tenant   @relation(fields: [tenant_id], references: [id], onDelete: Cascade)
+  creditor         Creditor @relation(fields: [creditor_id], references: [id], onDelete: Cascade)
 
   @@index([tenant_id])
   @@index([creditor_id])
@@ -393,29 +406,29 @@ model AuditLog {
 }
 
 model UserActivityLog {
-  id          String    @id @default(uuid())
+  id          String   @id @default(uuid())
   tenant_id   String?
   user_id     String?
   ip_address  String?
   user_agent  String?
   event       String?
-  recorded_at DateTime  @default(now())
-  updated_at  DateTime  @updatedAt
-  tenant      Tenant?   @relation(fields: [tenant_id], references: [id], onDelete: Cascade)
-  user        User?     @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  recorded_at DateTime @default(now())
+  updated_at  DateTime @updatedAt
+  tenant      Tenant?  @relation(fields: [tenant_id], references: [id], onDelete: Cascade)
+  user        User?    @relation(fields: [user_id], references: [id], onDelete: Cascade)
 
   @@index([tenant_id])
   @@map("user_activity_logs")
 }
 
 model ValidationIssue {
-  id          String    @id @default(uuid())
+  id          String   @id @default(uuid())
   tenant_id   String?
   entity_type String
   entity_id   String
   message     String
-  created_at  DateTime  @default(now())
-  tenant      Tenant?   @relation(fields: [tenant_id], references: [id], onDelete: Cascade)
+  created_at  DateTime @default(now())
+  tenant      Tenant?  @relation(fields: [tenant_id], references: [id], onDelete: Cascade)
 
   @@index([tenant_id])
   @@map("validation_issues")


### PR DESCRIPTION
## Summary
- update docs to use `pumps.name` instead of `label`
- add missing `TenantSettingsKv` model to Prisma
- regenerate Prisma client
- record fix in changelog and summaries

## Testing
- `npx --yes prisma@6.10.1 format --schema=prisma/schema.prisma`
- `npx --yes prisma@6.10.1 generate`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68664adc7ff483208632300c713a986d