### PR TITLE
Fix tenant ID access in dashboard metrics

### DIFF
--- a/src/controllers/dashboard.controller.ts
+++ b/src/controllers/dashboard.controller.ts
@@ -239,7 +239,7 @@ export function createDashboardHandlers(db: Pool) {
       }
     },
 
-    getStationMetrics: async (_req: Request, res: Response) => {
+    getStationMetrics: async (req: Request, res: Response) => {
       try {
         const tenantId = req.user?.tenantId;
         if (!tenantId) return errorResponse(res, 400, 'Missing tenant context');


### PR DESCRIPTION
## Summary
- use request object in `getStationMetrics` handler

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867a7dfe1108320b0020bbc9412b542