### PR TITLE
Fix station metrics typing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2975,3 +2975,12 @@ Each entry is tied to a step from the implementation index.
 * `package.json`
 * `package-lock.json`
 * `docs/STEP_fix_20251216.md`
+
+## [Fix 2025-12-17] – Station metrics compile fix
+
+### 🟥 Fixes
+* Cast station listing results to `any[]` so the `metrics` property can be assigned without TypeScript errors.
+
+### Files
+* `src/services/station.service.ts`
+* `docs/STEP_fix_20251217.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -243,3 +243,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-12-14 | Uniform dashboard empty handling | ✅ Done | `src/controllers/dashboard.controller.ts` | `docs/STEP_fix_20251214.md` |
 | fix | 2025-12-15 | Explicit empty list handling | ✅ Done | `src/controllers/*` | `docs/STEP_fix_20251215.md` |
 | fix | 2025-12-16 | Node types for build | ✅ Done | `package.json` | `docs/STEP_fix_20251216.md` |
+| fix | 2025-12-17 | Station metrics compile fix | ✅ Done | `src/services/station.service.ts` | `docs/STEP_fix_20251217.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1309,3 +1309,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Added `@types/node` to devDependencies so `tsc` succeeds without missing type errors.
+
+### 🛠️ Fix 2025-12-17 – Station metrics compile fix
+**Status:** ✅ Done
+**Files:** `src/services/station.service.ts`, `docs/STEP_fix_20251217.md`
+
+**Overview:**
+* Cast station listing results to `any[]` so the `metrics` property can be assigned without compile errors.

--- a/docs/STEP_fix_20251217.md
+++ b/docs/STEP_fix_20251217.md
@@ -1,0 +1,16 @@
+# STEP_fix_20251217.md — Station metrics compile fix
+
+## Project Context Summary
+Recent TypeScript builds failed after installing dependencies. The `listStations` function assigns a `metrics` property to each station object when the caller requests metrics. The parsed rows were strongly typed and did not allow this dynamic property, causing a compile error.
+
+## Steps Already Implemented
+Backend Phase 2 is complete with numerous fixes through 2025‑12‑16 including Node typings.
+
+## What Was Done Now
+- Cast the result of `parseRows` to `any[]` in `listStations` so the `metrics` property can be added.
+- Verified `npm run build` succeeds.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`

--- a/src/services/station.service.ts
+++ b/src/services/station.service.ts
@@ -71,7 +71,7 @@ export async function listStations(db: Pool, tenantId: string, includeMetrics = 
     [tenantId]
   );
 
-  const stations = parseRows(res.rows);
+  const stations = parseRows(res.rows) as any[];
   if (!includeMetrics) return stations;
 
   for (const st of stations) {


### PR DESCRIPTION
## Summary
- cast station list rows to `any[]` so metrics property can be assigned
- document TypeScript compile fix

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686932c4d60083208c2301c1638c1848