### PR TITLE
Fix Prisma price helper typing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2984,3 +2984,12 @@ Each entry is tied to a step from the implementation index.
 ### Files
 * `src/services/station.service.ts`
 * `docs/STEP_fix_20251217.md`
+
+## [Fix 2025-12-18] – Prisma price helper typing
+
+### 🟥 Fixes
+* Changed `getPriceAtTimestamp` to accept `PrismaClient` so service calls compile.
+
+### Files
+* `src/utils/priceUtils.ts`
+* `docs/STEP_fix_20251218.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -244,3 +244,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-12-15 | Explicit empty list handling | ✅ Done | `src/controllers/*` | `docs/STEP_fix_20251215.md` |
 | fix | 2025-12-16 | Node types for build | ✅ Done | `package.json` | `docs/STEP_fix_20251216.md` |
 | fix | 2025-12-17 | Station metrics compile fix | ✅ Done | `src/services/station.service.ts` | `docs/STEP_fix_20251217.md` |
+| fix | 2025-12-18 | Prisma price helper typing | ✅ Done | `src/utils/priceUtils.ts` | `docs/STEP_fix_20251218.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1316,3 +1316,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Cast station listing results to `any[]` so the `metrics` property can be assigned without compile errors.
+
+### 🛠️ Fix 2025-12-18 – Prisma price helper typing
+**Status:** ✅ Done
+**Files:** `src/utils/priceUtils.ts`, `docs/STEP_fix_20251218.md`
+
+**Overview:**
+* Updated `getPriceAtTimestamp` to accept `PrismaClient` directly, resolving build errors when called from services.

--- a/docs/STEP_fix_20251218.md
+++ b/docs/STEP_fix_20251218.md
@@ -1,0 +1,13 @@
+# STEP_fix_20251218.md — Prisma client parameter fix
+
+## Project Context Summary
+A TypeScript error occurred when building because `getPriceAtTimestamp` expected a `TxClient` type that didn't align with `PrismaClient`. Passing the prisma instance from services resulted in a mismatch.
+
+## What Was Done Now
+- Modified `src/utils/priceUtils.ts` so the helper accepts `PrismaClient` directly.
+- Ran `npm install` and `npm run build` to confirm the build succeeds without errors.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`

--- a/docs/STEP_fix_20251218_COMMAND.md
+++ b/docs/STEP_fix_20251218_COMMAND.md
@@ -1,0 +1,17 @@
+# STEP_fix_20251218_COMMAND.md
+
+## Project Context Summary
+`npm run build` failed with a type error in `attendant.service.ts` when calling `getPriceAtTimestamp(prisma, ...)`. The helper's parameter type was a custom `TxClient` union that no longer matches `PrismaClient`.
+
+## Steps Already Implemented
+Fixes are recorded through `STEP_fix_20251217.md` and the project builds using pg pools and Prisma.
+
+## What to Build Now
+- Update `src/utils/priceUtils.ts` so `getPriceAtTimestamp` accepts a `PrismaClient` parameter instead of `TxClient`.
+- Verify `npm run build` succeeds.
+- Document the fix in `CHANGELOG.md`, `IMPLEMENTATION_INDEX.md`, and `PHASE_2_SUMMARY.md`.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`

--- a/src/utils/priceUtils.ts
+++ b/src/utils/priceUtils.ts
@@ -1,6 +1,4 @@
-import { Prisma, PrismaClient } from '@prisma/client';
-
-type TxClient = PrismaClient | Prisma.TransactionClient;
+import { PrismaClient } from '@prisma/client';
 
 export interface PriceRecord {
   price: number;
@@ -8,7 +6,7 @@ export interface PriceRecord {
 }
 
 export async function getPriceAtTimestamp(
-  client: TxClient,
+  client: PrismaClient,
   tenantId: string,
   stationId: string,
   fuelType: string,


### PR DESCRIPTION
## Summary
- fix `getPriceAtTimestamp` argument type
- document build fix for Prisma helper

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68693f452d988320bb0dd6993db5459a