### PR TITLE
Fix build errors in station and attendant services

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2993,3 +2993,14 @@ Each entry is tied to a step from the implementation index.
 ### Files
 * `src/utils/priceUtils.ts`
 * `docs/STEP_fix_20251218.md`
+
+## [Fix 2025-12-19] – Station list typing and price lookup
+
+### 🟥 Fixes
+* Passed the transaction client to `getPriceAtTimestamp` in `createCashReport`.
+* Cast station listing results to `any[]` to allow appending metrics.
+
+### Files
+* `src/services/attendant.service.ts`
+* `src/services/station.service.ts`
+* `docs/STEP_fix_20251219.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -245,3 +245,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-12-16 | Node types for build | ✅ Done | `package.json` | `docs/STEP_fix_20251216.md` |
 | fix | 2025-12-17 | Station metrics compile fix | ✅ Done | `src/services/station.service.ts` | `docs/STEP_fix_20251217.md` |
 | fix | 2025-12-18 | Prisma price helper typing | ✅ Done | `src/utils/priceUtils.ts` | `docs/STEP_fix_20251218.md` |
+| fix | 2025-12-19 | Station list typing and price lookup | ✅ Done | `src/services/attendant.service.ts`, `src/services/station.service.ts` | `docs/STEP_fix_20251219.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1323,3 +1323,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Updated `getPriceAtTimestamp` to accept `PrismaClient` directly, resolving build errors when called from services.
+
+### 🛠️ Fix 2025-12-19 – Station list typing and price lookup
+**Status:** ✅ Done
+**Files:** `src/services/attendant.service.ts`, `src/services/station.service.ts`, `docs/STEP_fix_20251219.md`
+
+**Overview:**
+* Passed the pg transaction client to `getPriceAtTimestamp` in cash report creation.
+* Cast station listing results to `any[]` so metrics can be attached without type errors.

--- a/docs/STEP_fix_20251219.md
+++ b/docs/STEP_fix_20251219.md
@@ -1,0 +1,17 @@
+# STEP_fix_20251219.md — Price lookup client fix
+
+## Project Context Summary
+Running `npm run build` failed after recent merges. The `createCashReport` function passed the Prisma client to `getPriceAtTimestamp`, which expects a pg client. In `listStations`, the generated array was strongly typed and adding a `metrics` property caused a compile error.
+
+## Steps Already Implemented
+Backend phase 2 is finished through the 2025‑12‑18 fix for `getPriceAtTimestamp` typing.
+
+## What Was Done Now
+- Updated `createCashReport` to pass the transaction client and removed the unused Prisma import.
+- Cast the array in `listStations` to `any[]` so metrics can be assigned.
+- Installed dependencies and confirmed `npm run build` succeeds.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`

--- a/src/services/attendant.service.ts
+++ b/src/services/attendant.service.ts
@@ -1,6 +1,5 @@
 import { Pool } from 'pg';
 import { randomUUID } from 'crypto';
-import prisma from '../utils/prisma';
 import { parseRows } from '../utils/parseDb';
 import { getPriceAtTimestamp } from '../utils/priceUtils';
 import { incrementCreditorBalance } from './creditor.service';
@@ -86,7 +85,7 @@ export async function createCashReport(
       }
       const nozzleId = nozzleRes.rows[0].id;
         const priceRec = await getPriceAtTimestamp(
-          prisma,
+          client,
           tenantId,
           stationId,
           entry.fuelType,

--- a/src/services/station.service.ts
+++ b/src/services/station.service.ts
@@ -81,7 +81,7 @@ export async function listStations(
     attendantCount: 0,
     pumpCount: st._count.pumps,
     createdAt: st.created_at,
-  }));
+  })) as any[];
   if (!includeMetrics) return result;
   for (const st of result) {
     st.metrics = await getStationMetrics(_db, tenantId, st.id, 'today');


### PR DESCRIPTION
## Summary
- pass PG client to `getPriceAtTimestamp`
- allow metrics assignment in station list
- document fix step

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68694dea22e08320b2acaa4ffe1ef5e6