### PR TITLE
Fix dashboard station access checks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3043,3 +3043,15 @@ Each entry is tied to a step from the implementation index.
 * `docs/AZURE_DEV_SETUP.md`
 * `README.md`
 * `docs/STEP_fix_20260716_COMMAND.md`
+
+## [Fix 2026-07-17] – Dashboard station access
+
+### 🟥 Fixes
+* Dashboard controller endpoints validate station access via `user_stations`.
+* Return 403 when access is denied.
+* Added unit tests for the new logic.
+
+### Files
+* `src/controllers/dashboard.controller.ts`
+* `tests/dashboard.controller.test.ts`
+* `docs/STEP_fix_20260717_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -255,3 +255,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-07-15 | Pumps listing default | ✅ Done | `src/hooks/api/usePumps.ts` | `docs/STEP_fix_20260715_COMMAND.md` |
 | 3     | 3.16 | Owner analytics dashboard | ✅ Done | `src/pages/dashboard/AnalyticsPage.tsx` | `PHASE_3_SUMMARY.md#step-3.16` |
 | fix | 2026-07-16 | Azure deployment docs | ✅ Done | `docs/AZURE_DEPLOYMENT_GUIDE.md`, `docs/AZURE_DEV_SETUP.md`, `README.md` | `docs/STEP_fix_20260716_COMMAND.md` |
+| fix | 2026-07-17 | Dashboard station access | ✅ Done | `src/controllers/dashboard.controller.ts`, `tests/dashboard.controller.test.ts` | `docs/STEP_fix_20260717_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1349,3 +1349,12 @@ sudo apt-get update && sudo apt-get install -y postgresql
 * Documented environment variables and Azure setup script usage.
 * Added a developer guide for connecting to an Azure database.
 * Linked both guides from the README.
+
+### 🛠️ Fix 2026-07-17 – Dashboard station access
+**Status:** ✅ Done
+**Files:** `src/controllers/dashboard.controller.ts`, `tests/dashboard.controller.test.ts`, `docs/STEP_fix_20260717_COMMAND.md`
+
+**Overview:**
+* Added `user_stations` check to all dashboard endpoints with `stationId`.
+* Handlers return a 403 response when the user lacks access.
+* Added unit tests for the new validation logic.

--- a/docs/STEP_fix_20260717.md
+++ b/docs/STEP_fix_20260717.md
@@ -1,0 +1,24 @@
+# STEP_fix_20260717.md — Dashboard station access
+
+## Project Context Summary
+Dashboard metrics APIs allowed any authenticated owner or manager to supply a
+`stationId` without verifying membership. Other controllers implemented a
+`user_stations` check to enforce station-level permissions.
+
+## Steps Already Implemented
+Fix steps through `2026-07-16` introduced Azure deployment docs. Sales
+controller already validates station access.
+
+## What We Built
+- Added station access validation to all dashboard controller handlers that
+  accept a `stationId` query parameter.
+- Handlers return a 403 error when the requesting user is not linked to the
+  station via `public.user_stations`.
+- Added unit tests covering the `getSalesSummary` handler for both allowed and
+  denied scenarios.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260717_COMMAND.md`

--- a/docs/STEP_fix_20260717_COMMAND.md
+++ b/docs/STEP_fix_20260717_COMMAND.md
@@ -1,0 +1,24 @@
+# STEP_fix_20260717_COMMAND.md
+
+## Project Context Summary
+Dashboard controller endpoints accept an optional `stationId` but do not verify that
+the requesting user has access to that station. Other controllers like `sales.controller.ts`
+check `public.user_stations` to enforce station-level permissions.
+
+## Steps Already Implemented
+All fixes through `2026-07-16` are recorded. Access checks exist in `sales.controller.ts`
+and middleware but were missing in dashboard endpoints.
+
+## What to Build Now
+- Update `src/controllers/dashboard.controller.ts` to validate station access
+  before executing queries. Use the same query pattern as in `sales.controller.ts`.
+  Return a 403 error via `errorResponse` when access is denied.
+- Add unit tests for `createDashboardHandlers.getSalesSummary` covering access
+denied and allowed scenarios.
+- Document the fix in the changelog, implementation index and phase summary.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260717_COMMAND.md`

--- a/src/controllers/dashboard.controller.ts
+++ b/src/controllers/dashboard.controller.ts
@@ -10,8 +10,18 @@ export function createDashboardHandlers(db: Pool) {
   return {
     getSalesSummary: async (req: Request, res: Response) => {
       try {
-        const tenantId = req.user?.tenantId;
+        const user = req.user;
+        const tenantId = user?.tenantId;
         const stationId = normalizeStationId(req.query.stationId as string | undefined);
+        if (stationId) {
+          const access = await db.query(
+            `SELECT 1 FROM public.user_stations WHERE user_id = $1 AND station_id = $2 AND tenant_id = $3`,
+            [user?.userId, stationId, tenantId]
+          );
+          if (!access.rowCount) {
+            return errorResponse(res, 403, 'Station access denied');
+          }
+        }
         const range = (req.query.range as string) || 'monthly';
 
         let dateFilter = '';
@@ -62,8 +72,18 @@ export function createDashboardHandlers(db: Pool) {
 
     getPaymentMethodBreakdown: async (req: Request, res: Response) => {
       try {
-        const tenantId = req.user?.tenantId;
+        const user = req.user;
+        const tenantId = user?.tenantId;
         const stationId = normalizeStationId(req.query.stationId as string | undefined);
+        if (stationId) {
+          const access = await db.query(
+            `SELECT 1 FROM public.user_stations WHERE user_id = $1 AND station_id = $2 AND tenant_id = $3`,
+            [user?.userId, stationId, tenantId]
+          );
+          if (!access.rowCount) {
+            return errorResponse(res, 403, 'Station access denied');
+          }
+        }
         const dateFrom = req.query.dateFrom as string | undefined;
         const dateTo = req.query.dateTo as string | undefined;
 
@@ -119,8 +139,18 @@ export function createDashboardHandlers(db: Pool) {
 
     getFuelTypeBreakdown: async (req: Request, res: Response) => {
       try {
-        const tenantId = req.user?.tenantId;
+        const user = req.user;
+        const tenantId = user?.tenantId;
         const stationId = normalizeStationId(req.query.stationId as string | undefined);
+        if (stationId) {
+          const access = await db.query(
+            `SELECT 1 FROM public.user_stations WHERE user_id = $1 AND station_id = $2 AND tenant_id = $3`,
+            [user?.userId, stationId, tenantId]
+          );
+          if (!access.rowCount) {
+            return errorResponse(res, 403, 'Station access denied');
+          }
+        }
         const period = (req.query.period as string) || 'monthly';
 
         let dateFilter = '';
@@ -173,8 +203,18 @@ export function createDashboardHandlers(db: Pool) {
 
     getTopCreditors: async (req: Request, res: Response) => {
       try {
-        const tenantId = req.user?.tenantId;
+        const user = req.user;
+        const tenantId = user?.tenantId;
         const stationId = normalizeStationId(req.query.stationId as string | undefined);
+        if (stationId) {
+          const access = await db.query(
+            `SELECT 1 FROM public.user_stations WHERE user_id = $1 AND station_id = $2 AND tenant_id = $3`,
+            [user?.userId, stationId, tenantId]
+          );
+          if (!access.rowCount) {
+            return errorResponse(res, 403, 'Station access denied');
+          }
+        }
         const limit = parseInt(req.query.limit as string) || 5;
 
         const query = `
@@ -216,8 +256,18 @@ export function createDashboardHandlers(db: Pool) {
 
     getDailySalesTrend: async (req: Request, res: Response) => {
       try {
-        const tenantId = req.user?.tenantId;
+        const user = req.user;
+        const tenantId = user?.tenantId;
         const stationId = normalizeStationId(req.query.stationId as string | undefined);
+        if (stationId) {
+          const access = await db.query(
+            `SELECT 1 FROM public.user_stations WHERE user_id = $1 AND station_id = $2 AND tenant_id = $3`,
+            [user?.userId, stationId, tenantId]
+          );
+          if (!access.rowCount) {
+            return errorResponse(res, 403, 'Station access denied');
+          }
+        }
         const days = parseInt(req.query.days as string) || 7;
 
         const query = `

--- a/tests/dashboard.controller.test.ts
+++ b/tests/dashboard.controller.test.ts
@@ -1,0 +1,62 @@
+import { createDashboardHandlers } from '../src/controllers/dashboard.controller';
+
+const db = {
+  query: jest.fn()
+} as any;
+
+const handlers = createDashboardHandlers(db);
+
+const res = {
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis()
+} as any;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('dashboard.controller.getSalesSummary', () => {
+  test('returns 403 when station access denied', async () => {
+    const req = {
+      user: { userId: 'u1', tenantId: 't1' },
+      query: { stationId: 's1' }
+    } as any;
+    db.query.mockResolvedValueOnce({ rowCount: 0 });
+
+    await handlers.getSalesSummary(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ success: false, message: 'Station access denied' });
+  });
+
+  test('executes query when access allowed', async () => {
+    const req = {
+      user: { userId: 'u1', tenantId: 't1' },
+      query: { stationId: 's1' }
+    } as any;
+    db.query.mockResolvedValueOnce({ rowCount: 1 });
+    db.query.mockResolvedValueOnce({ rows: [{
+      total_sales: 10,
+      total_profit: 2,
+      total_volume: 3,
+      transaction_count: 1,
+      profit_margin: 20
+    }] });
+
+    await handlers.getSalesSummary(req, res);
+
+    expect(db.query).toHaveBeenCalledTimes(2);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        totalRevenue: 10,
+        totalProfit: 2,
+        profitMargin: 20,
+        totalVolume: 3,
+        salesCount: 1,
+        period: 'monthly'
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- validate station access in dashboard controller
- add tests for dashboard station access validation
- document fix in step files and changelog

## Testing
- `npm run test:unit` *(fails: unable to provision test DB)*

------
https://chatgpt.com/codex/tasks/task_e_686a428b0ba083209588d8fa505a636e