### PR TITLE
Fix OpenAPI test paths

### DIFF
--- a/__tests__/integration/api-contract.test.ts
+++ b/__tests__/integration/api-contract.test.ts
@@ -6,7 +6,7 @@ import path from 'path';
 
 describe('API contract', () => {
   const app = createApp();
-  const specPath = path.resolve(__dirname, '../../docs/openapi-spec.yaml');
+  const specPath = path.resolve(__dirname, '../../docs/openapi.yaml');
   const doc = yaml.load(fs.readFileSync(specPath, 'utf8')) as any;
 
   for (const [route, methods] of Object.entries<any>(doc.paths || {})) {
@@ -14,7 +14,7 @@ describe('API contract', () => {
     if (route.includes('{')) continue;
     for (const [method] of Object.entries<any>(methods)) {
       test(`${method.toUpperCase()} ${route} responds`, async () => {
-        const url = route.replace('/api', '');
+        const url = route;
         const res = await (request(app) as any)[method](url);
         expect(res.status).not.toBe(404);
       });

--- a/__tests__/integration/openapiRoutes.test.ts
+++ b/__tests__/integration/openapiRoutes.test.ts
@@ -6,14 +6,14 @@ import path from 'path';
 
 describe('OpenAPI endpoint existence', () => {
   const app = createApp();
-  const specPath = path.resolve(__dirname, '../../docs/openapi-spec.yaml');
+  const specPath = path.resolve(__dirname, '../../docs/openapi.yaml');
   const doc = yaml.load(fs.readFileSync(specPath, 'utf8')) as any;
   const paths = doc.paths || {};
 
   for (const [route, methods] of Object.entries<any>(paths)) {
     if (route.includes('{')) continue; // skip paths with parameters
     if (methods.get) {
-      const url = route.replace('/api', ''); // adapt for test prefix
+      const url = route;
       test(`GET ${route} should respond`, async () => {
         const res = await request(app).get(url);
         expect(res.status).not.toBe(404);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3100,3 +3100,10 @@ Each entry is tied to a step from the implementation index.
 * Attendant dashboard and new reading pages no longer hit owner-only endpoints.
 * Updated attendant journey documentation.
 * `docs/STEP_fix_20260725_COMMAND.md`
+
+## [Fix 2026-07-26] – Update OpenAPI tests
+
+### 🟥 Fixes
+* Integration tests load `docs/openapi.yaml` instead of the removed `openapi-spec.yaml`.
+* Removed custom route prefix stripping so endpoints are tested at `/api/v1`.
+* `docs/STEP_fix_20260726_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -264,3 +264,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-07-22 | Fuel price service tests | ✅ Done | `backend/tests/fuelPrice.service.test.ts` | `docs/STEP_fix_20260722_COMMAND.md` |
 | fix | 2026-07-24 | Mobile sidebar toggle | ✅ Done | `src/components/layout/*` | `docs/STEP_fix_20260724_COMMAND.md` |
 | fix | 2026-07-25 | SuperAdmin sidebar toggle | ✅ Done | `src/components/layout/Header.tsx` | `docs/STEP_fix_20260725_COMMAND.md` |
+| fix | 2026-07-26 | Update OpenAPI test paths | ✅ Done | `__tests__/integration/api-contract.test.ts`, `__tests__/integration/openapiRoutes.test.ts` | `docs/STEP_fix_20260726_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1380,3 +1380,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Added unit tests to ensure overlapping ranges throw errors and open ranges are closed when a new price is created.
+
+### 🛠️ Fix 2026-07-26 – OpenAPI contract tests
+**Status:** ✅ Done
+**Files:** `__tests__/integration/api-contract.test.ts`, `__tests__/integration/openapiRoutes.test.ts`, `docs/STEP_fix_20260726_COMMAND.md`
+
+**Overview:**
+* Tests reference `docs/openapi.yaml` and hit `/api/v1` routes directly.

--- a/docs/STEP_fix_20260726.md
+++ b/docs/STEP_fix_20260726.md
@@ -1,0 +1,17 @@
+# STEP_fix_20260726.md — Update OpenAPI integration tests
+
+## Project Context Summary
+The previous test suite referenced a deprecated `openapi-spec.yaml` and removed the `/api` prefix when hitting routes. The canonical specification now resides in `docs/openapi.yaml`, and Express serves all endpoints under `/api/v1`.
+
+## Steps Already Implemented
+Fixes up to `2026-07-25` ensured attendant pages only call allowed endpoints.
+
+## What We Built
+- Updated both integration tests to read `docs/openapi.yaml`.
+- Removed custom prefix stripping so tests call the real `/api/v1` paths.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260726_COMMAND.md`

--- a/docs/STEP_fix_20260726_COMMAND.md
+++ b/docs/STEP_fix_20260726_COMMAND.md
@@ -1,0 +1,17 @@
+# STEP_fix_20260726_COMMAND.md
+
+## Project Context Summary
+Integration tests validating the OpenAPI spec referenced `docs/openapi-spec.yaml`, which has been removed. The current spec lives at `docs/openapi.yaml`. Tests also stripped the `/api` prefix from routes, calling `/v1` endpoints instead of the real `/api/v1` paths.
+
+## Steps Already Implemented
+All fixes through `2026-07-25` including attendant route restrictions are complete.
+
+## What to Build Now
+- Update `__tests__/integration/api-contract.test.ts` and `__tests__/integration/openapiRoutes.test.ts` to load `docs/openapi.yaml`.
+- Remove the `route.replace('/api', '')` logic so requests hit the `/api/v1` endpoints directly.
+- Document the change in CHANGELOG, IMPLEMENTATION_INDEX and PHASE summary.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`


### PR DESCRIPTION
## Summary
- update integration tests to load `docs/openapi.yaml`
- call API routes with the `/api/v1` prefix
- document the change

## Testing
- `npm test` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d059c48308320a9f48979696e1dbf