### PR TITLE
Remove outdated price restriction on nozzle readings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3107,3 +3107,9 @@ Each entry is tied to a step from the implementation index.
 * Integration tests load `docs/openapi.yaml` instead of the removed `openapi-spec.yaml`.
 * Removed custom route prefix stripping so endpoints are tested at `/api/v1`.
 * `docs/STEP_fix_20260726_COMMAND.md`
+
+## [Fix 2026-07-27] – Remove outdated price restriction
+
+### 🟥 Fixes
+* Nozzle readings no longer fail when a price is older than seven days.
+* `docs/STEP_fix_20260727_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -265,3 +265,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-07-24 | Mobile sidebar toggle | ✅ Done | `src/components/layout/*` | `docs/STEP_fix_20260724_COMMAND.md` |
 | fix | 2026-07-25 | SuperAdmin sidebar toggle | ✅ Done | `src/components/layout/Header.tsx` | `docs/STEP_fix_20260725_COMMAND.md` |
 | fix | 2026-07-26 | Update OpenAPI test paths | ✅ Done | `__tests__/integration/api-contract.test.ts`, `__tests__/integration/openapiRoutes.test.ts` | `docs/STEP_fix_20260726_COMMAND.md` |
+| fix | 2026-07-27 | Remove outdated price restriction | ✅ Done | `src/services/nozzleReading.service.ts` | `docs/STEP_fix_20260727_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1387,3 +1387,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Tests reference `docs/openapi.yaml` and hit `/api/v1` routes directly.
+
+### 🛠️ Fix 2026-07-27 – Remove outdated price restriction
+**Status:** ✅ Done
+**Files:** `src/services/nozzleReading.service.ts`, `docs/STEP_fix_20260727_COMMAND.md`
+
+**Overview:**
+* Removed the 7‑day fuel price validity check so older prices can still be used when recording readings.

--- a/docs/STEP_fix_20260727.md
+++ b/docs/STEP_fix_20260727.md
@@ -1,0 +1,16 @@
+# STEP_fix_20260727.md — Remove outdated price restriction
+
+## Project Context Summary
+Previously, nozzle readings failed if the associated fuel price was recorded more than seven days before the reading date.
+
+## Steps Already Implemented
+All fixes up to `2026-07-26` including updated OpenAPI contract tests.
+
+## What We Built
+- Deleted the 7‑day validity check in `nozzleReading.service.ts`. Readings now accept any price retrieved by `getPriceAtTimestamp`.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260727_COMMAND.md`

--- a/docs/STEP_fix_20260727_COMMAND.md
+++ b/docs/STEP_fix_20260727_COMMAND.md
@@ -1,0 +1,17 @@
+# STEP_fix_20260727_COMMAND.md
+
+## Project Context Summary
+Users reported hitting a `Fuel price outdated` error when submitting nozzle readings. The service rejected prices older than seven days even if a newer price was later recorded.
+
+## Steps Already Implemented
+Fixes through `2026-07-26` including OpenAPI contract test updates.
+
+## What to Build Now
+- Remove the outdated price validation from `src/services/nozzleReading.service.ts` so readings use the latest valid price without date restriction.
+- Document the change in the changelog, implementation index, and phase summary.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260727_COMMAND.md`

--- a/src/services/nozzleReading.service.ts
+++ b/src/services/nozzleReading.service.ts
@@ -79,12 +79,7 @@ export async function createNozzleReading(
     if (!priceRecord) {
       throw new Error(`Fuel price not found for ${fuel_type} at this station. Please set fuel prices before recording readings.`);
     }
-    const { price, validFrom } = priceRecord;
-    const threshold = new Date(data.recordedAt);
-    threshold.setDate(threshold.getDate() - 7);
-    if (validFrom < threshold) {
-      throw new Error('Fuel price outdated');
-    }
+    const { price } = priceRecord;
     const saleAmount = parseFloat((volumeSold * price).toFixed(2));
     if (data.creditorId) {
       const creditor = await getCreditorById(client, tenantId, data.creditorId);


### PR DESCRIPTION
## Summary
- remove the 7‑day fuel price validity check
- document fix step

## Testing
- `npm test` *(fails: start-dev-db.sh not found / environment issue)*

------
https://chatgpt.com/codex/tasks/task_e_686e94e1ee84832082badd2d08483cbd