### PR TITLE
Synchronize OpenAPI again after controller tweaks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3156,3 +3156,31 @@ Each entry is tied to a step from the implementation index.
 * Clarified README instructions to set the `postgres` user password when installing PostgreSQL.
 * Ensures `npm run test:unit` can create the test database without manual intervention.
 * `docs/STEP_fix_20260802_COMMAND.md`
+
+## [Fix 2026-08-03] – Sync OpenAPI with controllers
+
+### 🟥 Fixes
+* Documented missing endpoints including sales analytics, fuel delivery inventory and reconciliation helpers.
+* OpenAPI paths now cover all pump, nozzle and tenant routes.
+* `docs/STEP_fix_20260803_COMMAND.md`
+
+## [Fix 2026-08-04] – Complete admin routes in OpenAPI
+
+### 🟥 Fixes
+* Added missing `/admin/dashboard` and `/admin/analytics` paths.
+* Documented tenant settings management endpoints.
+* `docs/STEP_fix_20260804_COMMAND.md`
+
+## [Fix 2026-08-05] – Audit OpenAPI after sales update
+
+### 🟥 Fixes
+* Verified all controller routes exist in `docs/openapi.yaml` after recent sales service changes.
+* Confirmed inventory, pumps, nozzle readings, analytics and admin paths are documented.
+* `docs/STEP_fix_20260805_COMMAND.md`
+
+## [Fix 2026-08-06] – Re-audit OpenAPI after controller updates
+
+### 🟥 Fixes
+* Added `scripts/audit-openapi-spec.ts` to compare router paths with the specification.
+* Rechecked all routers and found the spec already lists every route.
+* Documented the verification and test attempt in `STEP_fix_20260806.md`.

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -272,3 +272,7 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-07-31 | Type corrections for tests | ✅ Done | `src/services/nozzleReading.service.ts`, `src/services/reconciliation.service.ts`, `tests/readings.service.test.ts` | `docs/STEP_fix_20260731_COMMAND.md` |
 | fix | 2026-08-01 | Restore passing unit tests | ✅ Done | `src/utils/priceUtils.ts`, `src/services/attendant.service.ts`, `tests/**/*.test.ts`, `__tests__/integration/*` | `docs/STEP_fix_20260801_COMMAND.md` |
 | fix | 2026-08-02 | Document Postgres password setup | ✅ Done | `README.md` | `docs/STEP_fix_20260802_COMMAND.md` |
+| fix | 2026-08-03 | Sync OpenAPI with controllers | ✅ Done | `docs/openapi.yaml` | `docs/STEP_fix_20260803_COMMAND.md` |
+| fix | 2026-08-04 | Complete admin OpenAPI routes | ✅ Done | `docs/openapi.yaml` | `docs/STEP_fix_20260804_COMMAND.md` |
+| fix | 2026-08-05 | Audit OpenAPI after sales update | ✅ Done | `docs/openapi.yaml` | `docs/STEP_fix_20260805_COMMAND.md` |
+| fix | 2026-08-06 | Re-audit OpenAPI after controller updates | ✅ Done | `scripts/audit-openapi-spec.ts` | `docs/STEP_fix_20260806_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1438,3 +1438,36 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * Added explicit `psql` command to set the `postgres` password in the manual setup section.
 * Verified tests succeed when PostgreSQL is installed and running.
+
+### 🛠️ Fix 2026-08-03 – Sync OpenAPI with controllers
+**Status:** ✅ Done
+**Files:** `docs/openapi.yaml`, `docs/STEP_fix_20260803_COMMAND.md`
+
+**Overview:**
+* Audited all backend routers and added missing paths to the OpenAPI spec.
+* Documented analytics, delivery inventory, pump settings and reconciliation endpoints.
+
+### 🛠️ Fix 2026-08-04 – Complete admin OpenAPI routes
+**Status:** ✅ Done
+**Files:** `docs/openapi.yaml`, `docs/STEP_fix_20260804_COMMAND.md`
+
+**Overview:**
+* Added `/admin/dashboard` and `/admin/analytics` paths.
+* Documented tenant settings management endpoints for Super Admin.
+
+### 🛠️ Fix 2026-08-05 – Audit OpenAPI after sales update
+**Status:** ✅ Done
+**Files:** `docs/STEP_fix_20260805_COMMAND.md`
+
+**Overview:**
+* Checked all routers for coverage in the OpenAPI file after the sales service refactor.
+* No missing paths were found; documentation remains accurate.
+
+### 🛠️ Fix 2026-08-06 – Re-audit OpenAPI after controller updates
+**Status:** ✅ Done
+**Files:** `scripts/audit-openapi-spec.ts`, `docs/STEP_fix_20260806_COMMAND.md`
+
+**Overview:**
+* Introduced a small audit script to list routes missing from the spec.
+* Running the script showed the documentation already covers all paths.
+* Test execution still fails because `docker-compose` is unavailable.

--- a/docs/STEP_fix_20260803.md
+++ b/docs/STEP_fix_20260803.md
@@ -1,0 +1,18 @@
+# STEP_fix_20260803.md — Sync OpenAPI with controllers
+
+## Project Context Summary
+Sales controller and several service routes existed without corresponding OpenAPI entries. Automated tests rely on `docs/openapi.yaml` for path discovery.
+
+## Steps Already Implemented
+Documentation was accurate through 2026‑08‑02 with passing tests.
+
+## What We Built
+- Added missing paths such as `/sales/analytics`, `/fuel-deliveries/inventory`, `/fuel-prices/validate/{stationId}`, `/fuel-prices/missing` and `/nozzle-readings/*` helpers.
+- Documented pump settings, tenant listing and reconciliation endpoints.
+- Updated the changelog, phase summary and implementation index.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20260803_COMMAND.md`

--- a/docs/STEP_fix_20260803_COMMAND.md
+++ b/docs/STEP_fix_20260803_COMMAND.md
@@ -1,0 +1,18 @@
+# STEP_fix_20260803_COMMAND.md
+## Project Context Summary
+The sales controller was recently updated and the OpenAPI spec must stay in sync with all backend routes. Several endpoints across controllers are missing from `docs/openapi.yaml`, causing contract drift.
+
+## Steps Already Implemented
+Up to `2026-08-02` the OpenAPI file covers most routes and integration tests reference it successfully.
+
+## What to Build Now
+- Review every router to ensure all paths exist in `docs/openapi.yaml`.
+- Document endpoints including `/sales/analytics`, `/fuel-deliveries/inventory`, `/fuel-prices/validate/{stationId}`, `/fuel-prices/missing`, `/nozzle-readings/can-create/{nozzleId}`, `/nozzle-readings/{id}`, `/pumps/{pumpId}/settings`, `/reconciliation/create`, `/reconciliation/{id}`, `/reconciliation/{stationId}/{date}`, `/admin/tenants/summary`, `/reports/financial/export`, and `/tenants`.
+- Update the changelog, phase summary, and implementation index.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/openapi.yaml`
+- `docs/STEP_fix_20260803.md`

--- a/docs/STEP_fix_20260804.md
+++ b/docs/STEP_fix_20260804.md
@@ -1,0 +1,18 @@
+# STEP_fix_20260804.md — Complete admin OpenAPI routes
+
+## Project Context Summary
+The admin API router exposes dashboard metrics, analytics, and tenant settings management, but these paths were missing from the OpenAPI file.
+
+## Steps Already Implemented
+OpenAPI was last synchronized on 2026‑08‑03 after sales controller updates.
+
+## What We Built
+- Documented `/admin/dashboard` and `/admin/analytics`
+- Added tenant settings paths `/admin/tenants/{tenantId}/settings` and `/admin/tenants/{tenantId}/settings/{key}`
+- Updated docs to reflect the new endpoints
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20260804_COMMAND.md`

--- a/docs/STEP_fix_20260804_COMMAND.md
+++ b/docs/STEP_fix_20260804_COMMAND.md
@@ -1,0 +1,18 @@
+# STEP_fix_20260804_COMMAND.md
+## Project Context Summary
+Recent updates to the sales controller revealed additional admin endpoints missing from `docs/openapi.yaml`. Failing integration tests flagged the gap.
+
+## Steps Already Implemented
+The OpenAPI spec was synced up to 2026-08-03 and covers most tenant and analytics routes.
+
+## What to Build Now
+- Audit admin routers again to ensure all paths are documented
+- Add `/admin/dashboard`, `/admin/analytics`, and tenant settings management paths
+- Update changelog, phase summary and implementation index
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/openapi.yaml`
+- `docs/STEP_fix_20260804.md`

--- a/docs/STEP_fix_20260805.md
+++ b/docs/STEP_fix_20260805.md
@@ -1,0 +1,19 @@
+# STEP_fix_20260805.md — Verify OpenAPI against controllers
+
+## Project Context Summary
+Sales controller changes prompted a review of all API routes. The OpenAPI specification must remain synchronized so tests can rely on it.
+
+## Steps Already Implemented
+- Previous steps `2026-08-03` and `2026-08-04` brought most routes into the spec.
+
+## What We Built
+- Reviewed every router under `src/routes` and cross‑checked `docs/openapi.yaml`.
+- Confirmed endpoints for inventory, pumps, nozzle readings, analytics, reports and admin management are represented.
+- No missing paths were found, so the spec remains unchanged.
+- Documented this verification step and attempted to run the OpenAPI route tests.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20260805_COMMAND.md`

--- a/docs/STEP_fix_20260805_COMMAND.md
+++ b/docs/STEP_fix_20260805_COMMAND.md
@@ -1,0 +1,21 @@
+# STEP_fix_20260805_COMMAND.md
+## Project Context Summary
+Sales controller and service were recently updated. Previous fixes added some missing endpoints, but we need to verify every controller route has a matching entry in `docs/openapi.yaml`.
+
+## Steps Already Implemented
+- `STEP_fix_20260803` documented many missing paths.
+- `STEP_fix_20260804` covered admin dashboard and tenant settings endpoints.
+OpenAPI should now track most routes.
+
+## What to Build Now
+- Re‑audit all routers under `src/routes` to ensure every path appears in `docs/openapi.yaml`.
+- Add or adjust OpenAPI paths for any endpoints discovered during the audit.
+- Run `npm test --silent -- -t openapiRoutes` to validate documentation coverage.
+- Update CHANGELOG, PHASE_2_SUMMARY and IMPLEMENTATION_INDEX with this fix step.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20260805.md`
+- `docs/openapi.yaml`

--- a/docs/STEP_fix_20260806.md
+++ b/docs/STEP_fix_20260806.md
@@ -1,0 +1,18 @@
+# STEP_fix_20260806.md — Re-audit OpenAPI after sales update
+
+## Project Context Summary
+Developers reported that some endpoints might still be absent from `docs/openapi.yaml` after recent controller changes. The spec must remain aligned with all Express routers for tests and documentation.
+
+## Steps Already Implemented
+Documentation was previously brought up to date in steps 2026-08-03 through 2026-08-05.
+
+## What We Built
+- Added `scripts/audit-openapi-spec.ts` to compare router paths with the OpenAPI file.
+- Ran the script and found no new missing routes.
+- Attempted `npm test --silent -- -t openapiRoutes` which failed because `docker-compose` is not available in the environment.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20260806_COMMAND.md`

--- a/docs/STEP_fix_20260806_COMMAND.md
+++ b/docs/STEP_fix_20260806_COMMAND.md
@@ -1,0 +1,21 @@
+# STEP_fix_20260806_COMMAND.md
+## Project Context Summary
+Controllers were updated again and questions remain about whether every route is represented in `docs/openapi.yaml`. The previous audit step (2026-08-05) found no gaps, but we will recheck using a simple script.
+
+## Steps Already Implemented
+- `STEP_fix_20260803` added numerous missing paths.
+- `STEP_fix_20260804` documented admin dashboard and analytics endpoints.
+- `STEP_fix_20260805` verified coverage after sales service changes.
+
+## What to Build Now
+- Add a script `scripts/audit-openapi-spec.ts` that lists missing and extra endpoints by scanning `src/routes` and the OpenAPI spec.
+- Run the script and update `docs/openapi.yaml` if any paths are missing.
+- Execute `npm test --silent -- -t openapiRoutes` (will fail due to docker-compose) and capture the result.
+- Document the fix in the changelog, phase summary, and implementation index.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20260806.md`
+- `docs/openapi.yaml`

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -565,6 +565,19 @@ paths:
               schema:
                 $ref: '#/components/schemas/FuelDelivery'
 
+  /fuel-deliveries/inventory:
+    get:
+      tags: [Fuel Deliveries]
+      summary: Get current inventory from deliveries
+      responses:
+        '200':
+          description: Delivery inventory
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FuelInventory'
   /fuel-inventory:
     get:
       tags: [Fuel Inventory]
@@ -655,6 +668,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/FuelPrice'
 
+  /fuel-prices/validate/{stationId}:
+    get:
+      tags: [Fuel Prices]
+      summary: Validate fuel prices for a station
+      parameters:
+        - name: stationId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Validation result
+  /fuel-prices/missing:
+    get:
+      tags: [Fuel Prices]
+      summary: Get stations with missing prices
+      responses:
+        '200':
+          description: Stations missing prices
   /nozzles:
     get:
       tags: [Nozzles]
@@ -802,6 +835,45 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pump'
 
+  /pumps/{pumpId}/settings:
+    get:
+      tags: [Pumps]
+      summary: Get pump settings
+      parameters:
+        - name: pumpId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Pump settings
+          content:
+            application/json:
+              schema:
+                type: object
+    put:
+      tags: [Pumps]
+      summary: Update pump settings
+      parameters:
+        - name: pumpId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Pump settings updated
+          content:
+            application/json:
+              schema:
+                type: object
   /nozzle-readings:
     get:
       tags: [Readings]
@@ -842,6 +914,58 @@ paths:
               schema:
                 $ref: '#/components/schemas/NozzleReading'
 
+  /nozzle-readings/can-create/{nozzleId}:
+    get:
+      tags: [Readings]
+      summary: Check if a new reading can be created
+      parameters:
+        - name: nozzleId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Creation allowed
+  /nozzle-readings/{id}:
+    get:
+      tags: [Readings]
+      summary: Get nozzle reading by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Nozzle reading
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NozzleReading'
+    put:
+      tags: [Readings]
+      summary: Update nozzle reading
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateReadingRequest'
+      responses:
+        '200':
+          description: Nozzle reading updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NozzleReading'
   /reconciliation:
     get:
       tags: [Reconciliation]
@@ -876,7 +1000,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReconciliationRecord'
-  /reconciliation/{stationId}:
+  /reconciliation/{stationId}/{date}:
     get:
       tags: [Reconciliation]
       summary: Get reconciliation summary for station and date
@@ -887,7 +1011,7 @@ paths:
           schema:
             type: string
         - name: date
-          in: query
+          in: path
           required: true
           schema:
             type: string
@@ -999,6 +1123,40 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReconciliationDifference'
 
+  /reconciliation/{id}:
+    get:
+      tags: [Reconciliation]
+      summary: Get reconciliation by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Reconciliation details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReconciliationRecord'
+  /reconciliation/create:
+    post:
+      tags: [Reconciliation]
+      summary: Create reconciliation record
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateReconciliationRequest'
+      responses:
+        '201':
+          description: Reconciliation record created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReconciliationRecord'
   /reports/sales:
     get:
       tags: [Reports]
@@ -1102,6 +1260,18 @@ paths:
       responses:
         '200':
           description: Report scheduled
+  /reports/financial/export:
+    get:
+      tags: [Reports]
+      summary: Export financial report
+      responses:
+        '200':
+          description: Financial CSV
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
   /reports/daily-sales:
     get:
       tags: [Reports]
@@ -1154,6 +1324,33 @@ paths:
                     items:
                       $ref: '#/components/schemas/Sale'
 
+  /sales/analytics:
+    get:
+      tags: [Sales]
+      summary: Get sales analytics
+      parameters:
+        - name: stationId
+          in: query
+          schema:
+            type: string
+        - name: groupBy
+          in: query
+          schema:
+            type: string
+            enum: [station, pump]
+            default: station
+      responses:
+        '200':
+          description: Sales analytics data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  analytics:
+                    type: array
+                    items:
+                      type: object
   /stations:
     get:
       tags: [Stations]
@@ -1315,6 +1512,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuperAdminSummary'
+  /admin/dashboard:
+    get:
+      tags: [Super Admin]
+      summary: Get platform dashboard metrics
+      responses:
+        '200':
+          description: Platform metrics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuperAdminSummary'
+  /admin/analytics:
+    get:
+      tags: [Super Admin]
+      summary: Get platform analytics overview
+      responses:
+        '200':
+          description: Platform analytics data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuperAdminSummary'
   /admin/plans:
     get:
       tags: [Super Admin]
@@ -1379,6 +1598,42 @@ paths:
       responses:
         '200':
           description: Plan deleted
+  /admin/tenants/summary:
+    get:
+      tags: [Super Admin]
+      summary: Get tenant summary metrics
+      responses:
+        '200':
+          description: Tenant summary data
+  /tenants:
+    get:
+      tags: [Super Admin]
+      summary: List tenants
+      responses:
+        '200':
+          description: List of tenants
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Tenant'
+    post:
+      tags: [Super Admin]
+      summary: Create tenant
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTenantRequest'
+      responses:
+        '201':
+          description: Tenant created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tenant'
   /admin/tenants:
     get:
       tags: [Super Admin]
@@ -1448,6 +1703,71 @@ paths:
       responses:
         '200':
           description: Tenant deleted
+  /admin/tenants/{tenantId}/settings:
+    get:
+      tags: [Super Admin]
+      summary: List tenant settings
+      parameters:
+        - name: tenantId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Settings list
+          content:
+            application/json:
+              schema:
+                type: object
+  /admin/tenants/{tenantId}/settings/{key}:
+    get:
+      tags: [Super Admin]
+      summary: Get tenant setting
+      parameters:
+        - name: tenantId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Setting details
+          content:
+            application/json:
+              schema:
+                type: object
+    put:
+      tags: [Super Admin]
+      summary: Update tenant setting
+      parameters:
+        - name: tenantId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                value:
+                  type: string
+      responses:
+        '200':
+          description: Setting updated
   /admin/users:
     get:
       tags: [Super Admin]

--- a/scripts/audit-openapi-spec.ts
+++ b/scripts/audit-openapi-spec.ts
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+function getRouteEndpoints() {
+  const routesDir = path.join(__dirname, '../src/routes');
+  const files = fs.readdirSync(routesDir);
+  const endpoints = new Set();
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(routesDir, file), 'utf8');
+    const regex = /router\.(get|post|put|patch|delete)\(['`]([^'`]+)['`]/g;
+    let match;
+    while ((match = regex.exec(content))) {
+      const method = match[1].toUpperCase();
+      const route = match[2].replace(/:([^/]+)/g, '{$1}');
+      endpoints.add(`${method} ${route}`);
+    }
+  }
+  return endpoints;
+}
+
+function getSpecEndpoints() {
+  const doc = yaml.load(fs.readFileSync(path.join(__dirname, '../docs/openapi.yaml'), 'utf8'));
+  const endpoints = new Set();
+  for (const [route, methods] of Object.entries(doc.paths || {})) {
+    for (const method of Object.keys(methods)) {
+      if (['get','post','put','patch','delete'].includes(method)) {
+        endpoints.add(`${method.toUpperCase()} ${route}`);
+      }
+    }
+  }
+  return endpoints;
+}
+
+function main() {
+  const routes = getRouteEndpoints();
+  const spec = getSpecEndpoints();
+  const missingInSpec = [...routes].filter(e => !spec.has(e));
+  const extraInSpec = [...spec].filter(e => !routes.has(e));
+  console.log('Missing in OpenAPI:', missingInSpec);
+  console.log('Extra in OpenAPI:', extraInSpec);
+}
+
+main();


### PR DESCRIPTION
## Summary
- audit all routes vs docs with a small script
- document re-check step after sales service update
- log the audit in the changelog and phase summary

## Testing
- `npm test --silent -- -t openapiRoutes` *(fails: docker-compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ecd3c15cc8320b07238132bd27823