### PR TITLE
Fix openapi schema

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3184,3 +3184,11 @@ Each entry is tied to a step from the implementation index.
 * Added `scripts/audit-openapi-spec.ts` to compare router paths with the specification.
 * Rechecked all routers and found the spec already lists every route.
 * Documented the verification and test attempt in `STEP_fix_20260806.md`.
+
+## [Fix 2026-08-07] – Clean OpenAPI specification
+
+### 🟥 Fixes
+* Removed deprecated endpoints and unified enums.
+* Added operationIds, error response schemas and pagination parameters.
+* Authentication routes now explicitly disable security.
+* `docs/STEP_fix_20260807_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -276,3 +276,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-08-04 | Complete admin OpenAPI routes | ✅ Done | `docs/openapi.yaml` | `docs/STEP_fix_20260804_COMMAND.md` |
 | fix | 2026-08-05 | Audit OpenAPI after sales update | ✅ Done | `docs/openapi.yaml` | `docs/STEP_fix_20260805_COMMAND.md` |
 | fix | 2026-08-06 | Re-audit OpenAPI after controller updates | ✅ Done | `scripts/audit-openapi-spec.ts` | `docs/STEP_fix_20260806_COMMAND.md` |
+| fix | 2026-08-07 | Clean OpenAPI specification | ✅ Done | `docs/openapi.yaml`, `scripts/addOperationIds.js` | `docs/STEP_fix_20260807_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1471,3 +1471,12 @@ sudo apt-get update && sudo apt-get install -y postgresql
 * Introduced a small audit script to list routes missing from the spec.
 * Running the script showed the documentation already covers all paths.
 * Test execution still fails because `docker-compose` is unavailable.
+
+### 🛠️ Fix 2026-08-07 – Clean OpenAPI specification
+**Status:** ✅ Done
+**Files:** `docs/openapi.yaml`, `scripts/addOperationIds.js`, `docs/STEP_fix_20260807_COMMAND.md`
+
+**Overview:**
+* Removed deprecated endpoints and generated operationIds for every route.
+* Added reusable error and pagination components and updated all operations.
+* Authentication endpoints now bypass global security.

--- a/docs/STEP_fix_20260807.md
+++ b/docs/STEP_fix_20260807.md
@@ -1,0 +1,19 @@
+# STEP_fix_20260807.md — OpenAPI specification cleanup
+
+## Project Context Summary
+Multiple iterations left the API spec with deprecated endpoints, inconsistent enums and missing metadata. This step consolidates the documentation for better code generation and testing.
+
+## What We Built
+- Removed obsolete paths `/reconciliation/create`, `/settings` and `/dashboard/daily-trend`.
+- Added automatic `operationId` values and standard error responses to every operation.
+- Introduced `limit` and `offset` parameters for list endpoints via components.
+- Unified `fuelType`, `paymentMethod` and status enums.
+- Populated the `TenantAnalytics` schema and ensured `SystemHealth` properties exist.
+- Set `security: []` for authentication routes.
+- Inserted reusable `ErrorResponse` and pagination parameter definitions.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20260807_COMMAND.md`

--- a/docs/STEP_fix_20260807_COMMAND.md
+++ b/docs/STEP_fix_20260807_COMMAND.md
@@ -1,0 +1,23 @@
+# STEP_fix_20260807_COMMAND.md
+## Project Context Summary
+The OpenAPI specification has grown unwieldy after multiple quick fixes. Some deprecated paths remain and several schemas are inconsistent or incomplete. Enum values are repeated and responses lack standard error definitions. We need a clean spec for future code generation and testing.
+
+## Steps Already Implemented
+- Previous steps synced routes and audited the spec up to 2026-08-06.
+
+## What to Build Now
+- Remove deprecated paths `/reconciliation/create`, `/settings`, and `/dashboard/daily-trend` from `docs/openapi.yaml`.
+- Add `operationId` to each operation and include standard `ErrorResponse` schemas for 400, 401, 403 and 500 responses.
+- Ensure listing endpoints accept `limit` and `offset` parameters for pagination.
+- Consolidate `fuelType`, `paymentMethod` and status enums across schemas.
+- Add placeholder fields to `TenantAnalytics` and verify `SystemHealth` has basic properties.
+- Ensure authentication routes have `security: []` while others rely on global bearerAuth and tenantHeader.
+- Keep 2-space YAML indentation and alphabetize tags.
+- Update documentation (CHANGELOG, PHASE_2_SUMMARY, IMPLEMENTATION_INDEX) and create `STEP_fix_20260807.md` summarising the work.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20260807.md`
+- `docs/openapi.yaml`

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -12,7 +12,8 @@ security:
 paths:
   /auth/login:
     post:
-      tags: [Authentication]
+      tags:
+        - Authentication
       summary: User login
       requestBody:
         required: true
@@ -27,16 +28,70 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LoginResponse'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postauthLogin
+      security: []
   /auth/logout:
     post:
-      tags: [Authentication]
+      tags:
+        - Authentication
       summary: User logout
       responses:
         '200':
           description: Logout successful
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postauthLogout
+      security: []
   /auth/refresh:
     post:
-      tags: [Authentication]
+      tags:
+        - Authentication
       summary: Refresh authentication token
       responses:
         '200':
@@ -45,10 +100,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LoginResponse'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postauthRefresh
+      security: []
   /alerts:
     get:
-      tags: [Alerts]
+      tags:
+        - Alerts
       summary: Get all alerts
       responses:
         '200':
@@ -59,8 +140,37 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Alert'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getalerts
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
     post:
-      tags: [Alerts]
+      tags:
+        - Alerts
       summary: Create alert
       requestBody:
         required: true
@@ -75,9 +185,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Alert'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postalerts
   /alerts/summary:
     get:
-      tags: [Alerts]
+      tags:
+        - Alerts
       summary: Alert counts by severity
       responses:
         '200':
@@ -88,9 +224,35 @@ paths:
                 type: object
                 additionalProperties:
                   type: integer
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getalertsSummary
   /alerts/{id}/read:
     patch:
-      tags: [Alerts]
+      tags:
+        - Alerts
       summary: Mark alert as read
       parameters:
         - name: id
@@ -101,9 +263,35 @@ paths:
       responses:
         '200':
           description: Alert marked as read
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: patchalertsByidRead
   /alerts/{id}:
     delete:
-      tags: [Alerts]
+      tags:
+        - Alerts
       summary: Dismiss alert
       parameters:
         - name: id
@@ -114,10 +302,35 @@ paths:
       responses:
         '200':
           description: Alert dismissed
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: deletealertsByid
   /analytics/station-comparison:
     get:
-      tags: [Analytics]
+      tags:
+        - Analytics
       summary: Get station comparison data
       parameters:
         - name: period
@@ -130,6 +343,8 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Station comparison data
@@ -139,9 +354,35 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/StationComparison'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getanalyticsStationcomparison
   /analytics/hourly-sales:
     get:
-      tags: [Analytics]
+      tags:
+        - Analytics
       summary: Get hourly sales data
       parameters:
         - name: stationId
@@ -158,6 +399,8 @@ paths:
           schema:
             type: string
             format: date-time
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Hourly sales data
@@ -167,15 +410,43 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/HourlySales'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getanalyticsHourlysales
   /analytics/peak-hours:
     get:
-      tags: [Analytics]
+      tags:
+        - Analytics
       summary: Get peak hours data
       parameters:
         - name: stationId
           in: query
           schema:
             type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Peak hours data
@@ -185,9 +456,35 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PeakHour'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getanalyticsPeakhours
   /analytics/fuel-performance:
     get:
-      tags: [Analytics]
+      tags:
+        - Analytics
       summary: Get fuel performance data
       parameters:
         - name: stationId
@@ -204,6 +501,8 @@ paths:
           schema:
             type: string
             format: date-time
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Fuel performance data
@@ -213,9 +512,35 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FuelPerformance'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getanalyticsFuelperformance
   /analytics/superadmin:
     get:
-      tags: [Analytics]
+      tags:
+        - Analytics
       summary: Get super admin analytics
       responses:
         '200':
@@ -224,10 +549,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuperAdminAnalytics'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getanalyticsSuperadmin
   /analytics/tenant/{id}:
     get:
-      tags: [Analytics]
+      tags:
+        - Analytics
       summary: Get tenant analytics
       parameters:
         - name: id
@@ -242,10 +592,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TenantAnalytics'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getanalyticsTenantByid
   /creditors:
     get:
-      tags: [Creditors]
+      tags:
+        - Creditors
       summary: Get all creditors
       responses:
         '200':
@@ -256,8 +631,37 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Creditor'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getcreditors
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
     post:
-      tags: [Creditors]
+      tags:
+        - Creditors
       summary: Create new creditor
       requestBody:
         required: true
@@ -272,9 +676,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Creditor'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postcreditors
   /creditors/{id}:
     get:
-      tags: [Creditors]
+      tags:
+        - Creditors
       summary: Get creditor by ID
       parameters:
         - name: id
@@ -289,10 +719,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Creditor'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getcreditorsByid
   /credit-payments:
     get:
-      tags: [Credit Payments]
+      tags:
+        - Credit Payments
       summary: Get payments for a creditor
       parameters:
         - name: creditorId
@@ -300,6 +755,8 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: List of payments
@@ -309,8 +766,34 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/CreditPayment'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getcreditpayments
     post:
-      tags: [Credit Payments]
+      tags:
+        - Credit Payments
       summary: Create new payment
       requestBody:
         required: true
@@ -325,10 +808,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreditPayment'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postcreditpayments
   /dashboard/sales-summary:
     get:
-      tags: [Dashboard]
+      tags:
+        - Dashboard
       summary: Get sales summary
       parameters:
         - name: range
@@ -355,9 +863,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SalesSummary'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getdashboardSalessummary
   /dashboard/payment-methods:
     get:
-      tags: [Dashboard]
+      tags:
+        - Dashboard
       summary: Get payment method breakdown
       parameters:
         - name: stationId
@@ -372,6 +906,8 @@ paths:
           in: query
           schema:
             type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Payment method breakdown
@@ -381,9 +917,35 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PaymentMethodBreakdown'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getdashboardPaymentmethods
   /dashboard/fuel-breakdown:
     get:
-      tags: [Dashboard]
+      tags:
+        - Dashboard
       summary: Get fuel type breakdown
       parameters:
         - name: stationId
@@ -398,6 +960,8 @@ paths:
           in: query
           schema:
             type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Fuel type breakdown
@@ -407,10 +971,35 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FuelTypeBreakdown'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getdashboardFuelbreakdown
   /dashboard/fuel-types:
     get:
-      tags: [Dashboard]
+      tags:
+        - Dashboard
       summary: Get fuel type breakdown (deprecated)
       deprecated: true
       parameters:
@@ -426,6 +1015,8 @@ paths:
           in: query
           schema:
             type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Fuel type breakdown
@@ -435,9 +1026,35 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FuelTypeBreakdown'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getdashboardFueltypes
   /dashboard/top-creditors:
     get:
-      tags: [Dashboard]
+      tags:
+        - Dashboard
       summary: Get top creditors
       parameters:
         - name: limit
@@ -449,6 +1066,8 @@ paths:
           in: query
           schema:
             type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Top creditors list
@@ -458,9 +1077,35 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/TopCreditor'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getdashboardTopcreditors
   /dashboard/sales-trend:
     get:
-      tags: [Dashboard]
+      tags:
+        - Dashboard
       summary: Get daily sales trend
       parameters:
         - name: days
@@ -472,6 +1117,8 @@ paths:
           in: query
           schema:
             type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Daily sales trend
@@ -481,33 +1128,35 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/DailySalesTrend'
-  /dashboard/daily-trend:
-    get:
-      tags: [Dashboard]
-      summary: Get daily sales trend (deprecated)
-      deprecated: true
-      parameters:
-        - name: days
-          in: query
-          schema:
-            type: integer
-            default: 7
-        - name: stationId
-          in: query
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Daily sales trend
+        '400':
+          description: Error
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DailySalesTrend'
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getdashboardSalestrend
   /dashboard/station-metrics:
     get:
-      tags: [Dashboard]
+      tags:
+        - Dashboard
       summary: Get station metrics
       responses:
         '200':
@@ -518,9 +1167,38 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/StationMetric'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getdashboardStationmetrics
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
   /dashboard/system-health:
     get:
-      tags: [Dashboard]
+      tags:
+        - Dashboard
       summary: Get system health
       responses:
         '200':
@@ -529,16 +1207,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SystemHealth'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getdashboardSystemhealth
   /fuel-deliveries:
     get:
-      tags: [Fuel Deliveries]
+      tags:
+        - Fuel Deliveries
       summary: Get fuel deliveries
       parameters:
         - name: stationId
           in: query
           schema:
             type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: List of fuel deliveries
@@ -548,8 +1253,34 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FuelDelivery'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getfueldeliveries
     post:
-      tags: [Fuel Deliveries]
+      tags:
+        - Fuel Deliveries
       summary: Create new fuel delivery
       requestBody:
         required: true
@@ -564,10 +1295,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FuelDelivery'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postfueldeliveries
   /fuel-deliveries/inventory:
     get:
-      tags: [Fuel Deliveries]
+      tags:
+        - Fuel Deliveries
       summary: Get current inventory from deliveries
       responses:
         '200':
@@ -578,9 +1334,38 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FuelInventory'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getfueldeliveriesInventory
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
   /fuel-inventory:
     get:
-      tags: [Fuel Inventory]
+      tags:
+        - Fuel Inventory
       summary: Get fuel inventory status
       parameters:
         - name: stationId
@@ -591,7 +1376,12 @@ paths:
           in: query
           schema:
             type: string
-            enum: [petrol, diesel]
+            enum:
+              - petrol
+              - diesel
+              - premium
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Fuel inventory data
@@ -601,9 +1391,35 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FuelInventory'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getfuelinventory
   /fuel-inventory/summary:
     get:
-      tags: [Fuel Inventory]
+      tags:
+        - Fuel Inventory
       summary: Aggregate inventory totals by fuel type
       responses:
         '200':
@@ -614,10 +1430,38 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FuelInventorySummary'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getfuelinventorySummary
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
   /fuel-prices:
     get:
-      tags: [Fuel Prices]
+      tags:
+        - Fuel Prices
       summary: Get all fuel prices
       responses:
         '200':
@@ -628,8 +1472,37 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FuelPrice'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getfuelprices
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
     post:
-      tags: [Fuel Prices]
+      tags:
+        - Fuel Prices
       summary: Create new fuel price
       requestBody:
         required: true
@@ -644,9 +1517,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FuelPrice'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postfuelprices
   /fuel-prices/{id}:
     put:
-      tags: [Fuel Prices]
+      tags:
+        - Fuel Prices
       summary: Update fuel price
       parameters:
         - name: id
@@ -667,10 +1566,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FuelPrice'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: putfuelpricesByid
   /fuel-prices/validate/{stationId}:
     get:
-      tags: [Fuel Prices]
+      tags:
+        - Fuel Prices
       summary: Validate fuel prices for a station
       parameters:
         - name: stationId
@@ -681,16 +1605,68 @@ paths:
       responses:
         '200':
           description: Validation result
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getfuelpricesValidateBystationId
   /fuel-prices/missing:
     get:
-      tags: [Fuel Prices]
+      tags:
+        - Fuel Prices
       summary: Get stations with missing prices
       responses:
         '200':
           description: Stations missing prices
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getfuelpricesMissing
   /nozzles:
     get:
-      tags: [Nozzles]
+      tags:
+        - Nozzles
       summary: Get nozzles for a pump
       parameters:
         - name: pumpId
@@ -698,6 +1674,8 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: List of nozzles
@@ -707,8 +1685,34 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Nozzle'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getnozzles
     post:
-      tags: [Nozzles]
+      tags:
+        - Nozzles
       summary: Create new nozzle
       requestBody:
         required: true
@@ -723,10 +1727,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Nozzle'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postnozzles
   /nozzles/{nozzleId}:
     get:
-      tags: [Nozzles]
+      tags:
+        - Nozzles
       summary: Get nozzle by ID
       parameters:
         - name: nozzleId
@@ -741,10 +1770,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Nozzle'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getnozzlesBynozzleId
   /nozzles/{nozzleId}/settings:
     get:
-      tags: [Nozzles]
+      tags:
+        - Nozzles
       summary: Get nozzle settings
       parameters:
         - name: nozzleId
@@ -759,8 +1813,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NozzleSettings'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getnozzlesBynozzleIdSettings
     put:
-      tags: [Nozzles]
+      tags:
+        - Nozzles
       summary: Update nozzle settings
       parameters:
         - name: nozzleId
@@ -781,10 +1861,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NozzleSettings'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: putnozzlesBynozzleIdSettings
   /pumps:
     get:
-      tags: [Pumps]
+      tags:
+        - Pumps
       summary: Get pumps for a station
       parameters:
         - name: stationId
@@ -792,6 +1897,8 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: List of pumps
@@ -801,8 +1908,34 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Pump'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getpumps
     post:
-      tags: [Pumps]
+      tags:
+        - Pumps
       summary: Create new pump
       requestBody:
         required: true
@@ -817,9 +1950,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Pump'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postpumps
   /pumps/{pumpId}:
     get:
-      tags: [Pumps]
+      tags:
+        - Pumps
       summary: Get pump by ID
       parameters:
         - name: pumpId
@@ -834,10 +1993,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Pump'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getpumpsBypumpId
   /pumps/{pumpId}/settings:
     get:
-      tags: [Pumps]
+      tags:
+        - Pumps
       summary: Get pump settings
       parameters:
         - name: pumpId
@@ -852,8 +2036,34 @@ paths:
             application/json:
               schema:
                 type: object
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getpumpsBypumpIdSettings
     put:
-      tags: [Pumps]
+      tags:
+        - Pumps
       summary: Update pump settings
       parameters:
         - name: pumpId
@@ -874,9 +2084,35 @@ paths:
             application/json:
               schema:
                 type: object
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: putpumpsBypumpIdSettings
   /nozzle-readings:
     get:
-      tags: [Readings]
+      tags:
+        - Readings
       summary: Get nozzle readings
       parameters:
         - name: nozzleId
@@ -888,6 +2124,8 @@ paths:
           in: query
           schema:
             type: integer
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: List of nozzle readings
@@ -897,8 +2135,34 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/NozzleReading'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getnozzlereadings
     post:
-      tags: [Readings]
+      tags:
+        - Readings
       summary: Create new reading
       requestBody:
         required: true
@@ -913,10 +2177,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NozzleReading'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postnozzlereadings
   /nozzle-readings/can-create/{nozzleId}:
     get:
-      tags: [Readings]
+      tags:
+        - Readings
       summary: Check if a new reading can be created
       parameters:
         - name: nozzleId
@@ -927,9 +2216,35 @@ paths:
       responses:
         '200':
           description: Creation allowed
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getnozzlereadingsCancreateBynozzleId
   /nozzle-readings/{id}:
     get:
-      tags: [Readings]
+      tags:
+        - Readings
       summary: Get nozzle reading by ID
       parameters:
         - name: id
@@ -944,8 +2259,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NozzleReading'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getnozzlereadingsByid
     put:
-      tags: [Readings]
+      tags:
+        - Readings
       summary: Update nozzle reading
       parameters:
         - name: id
@@ -966,15 +2307,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NozzleReading'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: putnozzlereadingsByid
   /reconciliation:
     get:
-      tags: [Reconciliation]
+      tags:
+        - Reconciliation
       summary: Get reconciliation history
       parameters:
         - name: stationId
           in: query
           schema:
             type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Reconciliation history
@@ -984,8 +2353,34 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ReconciliationRecord'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getreconciliation
     post:
-      tags: [Reconciliation]
+      tags:
+        - Reconciliation
       summary: Create reconciliation record
       requestBody:
         required: true
@@ -1000,9 +2395,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReconciliationRecord'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postreconciliation
   /reconciliation/{stationId}/{date}:
     get:
-      tags: [Reconciliation]
+      tags:
+        - Reconciliation
       summary: Get reconciliation summary for station and date
       parameters:
         - name: stationId
@@ -1022,9 +2443,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReconciliationRecord'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getreconciliationBystationIdBydate
   /reconciliation/{id}/approve:
     post:
-      tags: [Reconciliation]
+      tags:
+        - Reconciliation
       summary: Approve reconciliation record
       parameters:
         - name: id
@@ -1035,9 +2482,35 @@ paths:
       responses:
         '200':
           description: Reconciliation approved
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postreconciliationByidApprove
   /reconciliation/daily-summary:
     get:
-      tags: [Reconciliation]
+      tags:
+        - Reconciliation
       summary: Get daily readings summary
       parameters:
         - name: stationId
@@ -1050,6 +2523,8 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Daily readings summary
@@ -1059,9 +2534,35 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/DailyReadingSummary'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getreconciliationDailysummary
   /reconciliation/differences:
     get:
-      tags: [Reconciliation]
+      tags:
+        - Reconciliation
       summary: List reconciliation differences
       parameters:
         - name: stationId
@@ -1082,7 +2583,12 @@ paths:
           in: query
           schema:
             type: string
-            enum: [match, over, short]
+            enum:
+              - match
+              - over
+              - short
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Differences list
@@ -1092,9 +2598,35 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ReconciliationDifference'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getreconciliationDifferences
   /reconciliation/differences/summary:
     get:
-      tags: [Reconciliation]
+      tags:
+        - Reconciliation
       summary: Summary of reconciliation discrepancies
       responses:
         '200':
@@ -1105,9 +2637,35 @@ paths:
                 type: object
                 additionalProperties:
                   type: number
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getreconciliationDifferencesSummary
   /reconciliation/differences/{id}:
     get:
-      tags: [Reconciliation]
+      tags:
+        - Reconciliation
       summary: Get reconciliation difference by ID
       parameters:
         - name: id
@@ -1122,10 +2680,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReconciliationDifference'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getreconciliationDifferencesByid
   /reconciliation/{id}:
     get:
-      tags: [Reconciliation]
+      tags:
+        - Reconciliation
       summary: Get reconciliation by ID
       parameters:
         - name: id
@@ -1140,26 +2723,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReconciliationRecord'
-  /reconciliation/create:
-    post:
-      tags: [Reconciliation]
-      summary: Create reconciliation record
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateReconciliationRequest'
-      responses:
-        '201':
-          description: Reconciliation record created
+        '400':
+          description: Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReconciliationRecord'
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getreconciliationByid
   /reports/sales:
     get:
-      tags: [Reports]
+      tags:
+        - Reports
       summary: Get sales report
       parameters:
         - name: startDate
@@ -1196,9 +2788,35 @@ paths:
                       $ref: '#/components/schemas/SalesReportData'
                   summary:
                     $ref: '#/components/schemas/SalesReportSummary'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getreportsSales
   /reports/sales/export:
     get:
-      tags: [Reports]
+      tags:
+        - Reports
       summary: Export sales report as CSV
       parameters:
         - name: startDate
@@ -1229,9 +2847,35 @@ paths:
               schema:
                 type: string
                 format: binary
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getreportsSalesExport
   /reports/export:
     post:
-      tags: [Reports]
+      tags:
+        - Reports
       summary: Export report
       requestBody:
         required: true
@@ -1247,9 +2891,35 @@ paths:
               schema:
                 type: string
                 format: binary
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postreportsExport
   /reports/schedule:
     post:
-      tags: [Reports]
+      tags:
+        - Reports
       summary: Schedule report
       requestBody:
         required: true
@@ -1260,9 +2930,35 @@ paths:
       responses:
         '200':
           description: Report scheduled
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postreportsSchedule
   /reports/financial/export:
     get:
-      tags: [Reports]
+      tags:
+        - Reports
       summary: Export financial report
       responses:
         '200':
@@ -1272,9 +2968,35 @@ paths:
               schema:
                 type: string
                 format: binary
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getreportsFinancialExport
   /reports/daily-sales:
     get:
-      tags: [Reports]
+      tags:
+        - Reports
       summary: Get consolidated daily sales
       parameters:
         - name: date
@@ -1289,10 +3011,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DailySalesReport'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getreportsDailysales
   /sales:
     get:
-      tags: [Sales]
+      tags:
+        - Sales
       summary: Get sales with filters
       parameters:
         - name: stationId
@@ -1323,10 +3070,35 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Sale'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getsales
   /sales/analytics:
     get:
-      tags: [Sales]
+      tags:
+        - Sales
       summary: Get sales analytics
       parameters:
         - name: stationId
@@ -1337,7 +3109,9 @@ paths:
           in: query
           schema:
             type: string
-            enum: [station, pump]
+            enum:
+              - station
+              - pump
             default: station
       responses:
         '200':
@@ -1351,15 +3125,43 @@ paths:
                     type: array
                     items:
                       type: object
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getsalesAnalytics
   /stations:
     get:
-      tags: [Stations]
+      tags:
+        - Stations
       summary: Get all stations
       parameters:
         - name: includeMetrics
           in: query
           schema:
             type: boolean
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: List of stations
@@ -1369,9 +3171,35 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Station'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getstations
   /stations/{stationId}:
     get:
-      tags: [Stations]
+      tags:
+        - Stations
       summary: Get station by ID
       parameters:
         - name: stationId
@@ -1386,10 +3214,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Station'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getstationsBystationId
   /stations/compare:
     get:
-      tags: [Stations]
+      tags:
+        - Stations
       summary: Compare stations
       parameters:
         - name: stationIds
@@ -1402,6 +3255,8 @@ paths:
           schema:
             type: string
             default: monthly
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Comparison data
@@ -1411,10 +3266,35 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/StationComparison'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getstationsCompare
   /stations/ranking:
     get:
-      tags: [Stations]
+      tags:
+        - Stations
       summary: Get station ranking
       parameters:
         - name: metric
@@ -1427,6 +3307,8 @@ paths:
           schema:
             type: string
             default: monthly
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: Station ranking
@@ -1436,10 +3318,35 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/StationRanking'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getstationsRanking
   /stations/{stationId}/metrics:
     get:
-      tags: [Stations]
+      tags:
+        - Stations
       summary: Get station metrics
       parameters:
         - name: stationId
@@ -1459,10 +3366,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StationMetrics'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getstationsBystationIdMetrics
   /stations/{stationId}/performance:
     get:
-      tags: [Stations]
+      tags:
+        - Stations
       summary: Get station performance
       parameters:
         - name: stationId
@@ -1482,10 +3414,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StationPerformance'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getstationsBystationIdPerformance
   /stations/{stationId}/efficiency:
     get:
-      tags: [Stations]
+      tags:
+        - Stations
       summary: Get station efficiency
       parameters:
         - name: stationId
@@ -1500,10 +3457,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StationEfficiency'
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getstationsBystationIdEfficiency
   /analytics/dashboard:
     get:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Get platform dashboard metrics
       responses:
         '200':
@@ -1512,9 +3494,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuperAdminSummary'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getanalyticsDashboard
   /admin/dashboard:
     get:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Get platform dashboard metrics
       responses:
         '200':
@@ -1523,9 +3531,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuperAdminSummary'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getadminDashboard
   /admin/analytics:
     get:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Get platform analytics overview
       responses:
         '200':
@@ -1534,9 +3568,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuperAdminSummary'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getadminAnalytics
   /admin/plans:
     get:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Get all plans
       responses:
         '200':
@@ -1547,8 +3607,37 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Plan'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getadminPlans
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
     post:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Create plan
       requestBody:
         required: true
@@ -1563,9 +3652,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Plan'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postadminPlans
   /admin/plans/{planId}:
     put:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Update plan
       parameters:
         - name: planId
@@ -1586,8 +3701,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Plan'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: putadminPlansByplanId
     delete:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Delete plan
       parameters:
         - name: planId
@@ -1598,16 +3739,68 @@ paths:
       responses:
         '200':
           description: Plan deleted
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: deleteadminPlansByplanId
   /admin/tenants/summary:
     get:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Get tenant summary metrics
       responses:
         '200':
           description: Tenant summary data
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getadminTenantsSummary
   /tenants:
     get:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: List tenants
       responses:
         '200':
@@ -1618,8 +3811,37 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Tenant'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: gettenants
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
     post:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Create tenant
       requestBody:
         required: true
@@ -1634,9 +3856,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Tenant'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: posttenants
   /admin/tenants:
     get:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Get all tenants
       responses:
         '200':
@@ -1647,8 +3895,37 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Tenant'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getadminTenants
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
     post:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Create tenant with admin
       requestBody:
         required: true
@@ -1663,9 +3940,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Tenant'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postadminTenants
   /admin/tenants/{tenantId}/status:
     patch:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Update tenant status
       parameters:
         - name: tenantId
@@ -1682,7 +3985,10 @@ paths:
               properties:
                 status:
                   type: string
-                  enum: [active, suspended, cancelled]
+                  enum:
+                    - active
+                    - suspended
+                    - cancelled
       responses:
         '200':
           description: Tenant status updated
@@ -1690,9 +3996,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Tenant'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: patchadminTenantsBytenantIdStatus
   /admin/tenants/{tenantId}:
     delete:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Delete tenant
       parameters:
         - name: tenantId
@@ -1703,9 +4035,35 @@ paths:
       responses:
         '200':
           description: Tenant deleted
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: deleteadminTenantsBytenantId
   /admin/tenants/{tenantId}/settings:
     get:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: List tenant settings
       parameters:
         - name: tenantId
@@ -1720,9 +4078,35 @@ paths:
             application/json:
               schema:
                 type: object
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getadminTenantsBytenantIdSettings
   /admin/tenants/{tenantId}/settings/{key}:
     get:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Get tenant setting
       parameters:
         - name: tenantId
@@ -1742,8 +4126,34 @@ paths:
             application/json:
               schema:
                 type: object
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getadminTenantsBytenantIdSettingsBykey
     put:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Update tenant setting
       parameters:
         - name: tenantId
@@ -1768,9 +4178,35 @@ paths:
       responses:
         '200':
           description: Setting updated
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: putadminTenantsBytenantIdSettingsBykey
   /admin/users:
     get:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Get admin users
       responses:
         '200':
@@ -1781,8 +4217,37 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/AdminUser'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getadminUsers
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
     post:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Create admin user
       requestBody:
         required: true
@@ -1797,9 +4262,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AdminUser'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postadminUsers
   /admin/users/{userId}:
     put:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Update admin user
       parameters:
         - name: userId
@@ -1825,8 +4316,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AdminUser'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: putadminUsersByuserId
     delete:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Delete admin user
       parameters:
         - name: userId
@@ -1837,9 +4354,35 @@ paths:
       responses:
         '200':
           description: Admin user deleted
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: deleteadminUsersByuserId
   /admin/users/{userId}/reset-password:
     post:
-      tags: [Super Admin]
+      tags:
+        - Super Admin
       summary: Reset admin user password
       parameters:
         - name: userId
@@ -1859,10 +4402,35 @@ paths:
       responses:
         '200':
           description: Password reset
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postadminUsersByuserIdResetpassword
   /users:
     get:
-      tags: [Users]
+      tags:
+        - Users
       summary: Get users for current tenant
       responses:
         '200':
@@ -1876,8 +4444,34 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/User'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getusers
     post:
-      tags: [Users]
+      tags:
+        - Users
       summary: Create new user
       requestBody:
         required: true
@@ -1892,9 +4486,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postusers
   /users/{userId}:
     get:
-      tags: [Users]
+      tags:
+        - Users
       summary: Get user by ID
       parameters:
         - name: userId
@@ -1909,8 +4529,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getusersByuserId
     put:
-      tags: [Users]
+      tags:
+        - Users
       summary: Update user
       parameters:
         - name: userId
@@ -1931,8 +4577,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: putusersByuserId
     delete:
-      tags: [Users]
+      tags:
+        - Users
       summary: Delete user
       parameters:
         - name: userId
@@ -1943,9 +4615,35 @@ paths:
       responses:
         '200':
           description: User deleted
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: deleteusersByuserId
   /users/{userId}/change-password:
     post:
-      tags: [Users]
+      tags:
+        - Users
       summary: Change user password
       parameters:
         - name: userId
@@ -1962,9 +4660,35 @@ paths:
       responses:
         '200':
           description: Password changed
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postusersByuserIdChangepassword
   /users/{userId}/reset-password:
     post:
-      tags: [Users]
+      tags:
+        - Users
       summary: Reset user password
       parameters:
         - name: userId
@@ -1981,10 +4705,35 @@ paths:
       responses:
         '200':
           description: Password reset
-
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postusersByuserIdResetpassword
   /admin/auth/login:
     post:
-      tags: [Admin Auth]
+      tags:
+        - Admin Auth
       summary: Admin login
       requestBody:
         required: true
@@ -1999,15 +4748,68 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LoginResponse'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postadminAuthLogin
+      security: []
   /tenant/settings:
     get:
-      tags: [Settings]
+      tags:
+        - Settings
       summary: Get tenant settings
       responses:
         '200':
           description: Settings list
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: gettenantSettings
     post:
-      tags: [Settings]
+      tags:
+        - Settings
       summary: Update tenant settings
       requestBody:
         required: true
@@ -2018,28 +4820,35 @@ paths:
       responses:
         '200':
           description: Settings updated
-  /settings:
-    get:
-      tags: [Settings]
-      summary: Get settings (deprecated)
-      responses:
-        '200':
-          description: Settings list
-    post:
-      tags: [Settings]
-      summary: Update settings (deprecated)
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        '200':
-          description: Settings updated
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: posttenantSettings
   /inventory:
     get:
-      tags: [Inventory]
+      tags:
+        - Inventory
       summary: Get fuel inventory
       parameters:
         - name: stationId
@@ -2050,9 +4859,35 @@ paths:
       responses:
         '200':
           description: Inventory details
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getinventory
   /inventory/update:
     post:
-      tags: [Inventory]
+      tags:
+        - Inventory
       summary: Update inventory
       requestBody:
         required: true
@@ -2063,9 +4898,35 @@ paths:
       responses:
         '200':
           description: Inventory updated
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postinventoryUpdate
   /inventory/alerts:
     get:
-      tags: [Inventory]
+      tags:
+        - Inventory
       summary: Get inventory alerts
       parameters:
         - name: stationId
@@ -2081,16 +4942,68 @@ paths:
       responses:
         '200':
           description: Alerts list
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getinventoryAlerts
   /attendant/stations:
     get:
-      tags: [Attendant]
+      tags:
+        - Attendant
       summary: List stations for attendant
       responses:
         '200':
           description: Station list
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getattendantStations
   /attendant/pumps:
     get:
-      tags: [Attendant]
+      tags:
+        - Attendant
       summary: List pumps for attendant
       parameters:
         - name: stationId
@@ -2101,9 +5014,35 @@ paths:
       responses:
         '200':
           description: Pump list
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getattendantPumps
   /attendant/nozzles:
     get:
-      tags: [Attendant]
+      tags:
+        - Attendant
       summary: List nozzles for attendant
       parameters:
         - name: pumpId
@@ -2114,16 +5053,68 @@ paths:
       responses:
         '200':
           description: Nozzle list
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getattendantNozzles
   /attendant/creditors:
     get:
-      tags: [Attendant]
+      tags:
+        - Attendant
       summary: List creditors for attendant
       responses:
         '200':
           description: Creditor list
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getattendantCreditors
   /attendant/cash-report:
     post:
-      tags: [Attendant]
+      tags:
+        - Attendant
       summary: Create cash report
       requestBody:
         required: true
@@ -2134,16 +5125,68 @@ paths:
       responses:
         '201':
           description: Report created
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postattendantCashreport
   /attendant/cash-reports:
     get:
-      tags: [Attendant]
+      tags:
+        - Attendant
       summary: List cash reports
       responses:
         '200':
           description: Report list
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getattendantCashreports
   /attendant/alerts:
     get:
-      tags: [Attendant]
+      tags:
+        - Attendant
       summary: List attendant alerts
       parameters:
         - name: stationId
@@ -2159,9 +5202,35 @@ paths:
       responses:
         '200':
           description: Alert list
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getattendantAlerts
   /attendant/alerts/{id}/acknowledge:
     put:
-      tags: [Attendant]
+      tags:
+        - Attendant
       summary: Acknowledge alert
       parameters:
         - name: id
@@ -2172,13 +5241,64 @@ paths:
       responses:
         '200':
           description: Alert acknowledged
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: putattendantAlertsByidAcknowledge
   /setup-status:
     get:
-      tags: [Setup]
+      tags:
+        - Setup
       summary: Get setup status
       responses:
         '200':
           description: Setup status
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: getsetupstatus
 components:
   securitySchemes:
     bearerAuth:
@@ -2189,11 +5309,12 @@ components:
       type: apiKey
       in: header
       name: x-tenant-id
-
   schemas:
     LoginRequest:
       type: object
-      required: [email, password]
+      required:
+        - email
+        - password
       properties:
         email:
           type: string
@@ -2216,7 +5337,11 @@ components:
               type: string
             role:
               type: string
-              enum: [superadmin, owner, manager, attendant]
+              enum:
+                - superadmin
+                - owner
+                - manager
+                - attendant
             tenantId:
               type: string
             tenantName:
@@ -2228,10 +5353,18 @@ components:
           type: string
         type:
           type: string
-          enum: [inventory, credit, maintenance, sales, system]
+          enum:
+            - inventory
+            - credit
+            - maintenance
+            - sales
+            - system
         severity:
           type: string
-          enum: [info, warning, critical]
+          enum:
+            - info
+            - warning
+            - critical
         title:
           type: string
         message:
@@ -2314,7 +5447,6 @@ components:
           type: number
         rank:
           type: number
-
     StationMetrics:
       type: object
       properties:
@@ -2324,7 +5456,6 @@ components:
           type: number
         transactionCount:
           type: integer
-
     StationPerformance:
       type: object
       properties:
@@ -2340,7 +5471,6 @@ components:
           type: number
         growth:
           type: number
-
     StationEfficiency:
       type: object
       properties:
@@ -2350,10 +5480,13 @@ components:
           type: string
         efficiency:
           type: number
-
     TenantAnalytics:
       type: object
-
+      properties:
+        totalStations:
+          type: number
+        totalSales:
+          type: number
     NozzleSettings:
       type: object
     SuperAdminAnalytics:
@@ -2406,7 +5539,10 @@ components:
           type: string
         status:
           type: string
-          enum: [active, inactive]
+          enum:
+            - active
+            - inactive
+            - maintenance
         createdAt:
           type: string
           format: date-time
@@ -2418,7 +5554,8 @@ components:
           type: number
     CreateCreditorRequest:
       type: object
-      required: [partyName]
+      required:
+        - partyName
       properties:
         partyName:
           type: string
@@ -2435,7 +5572,13 @@ components:
           type: number
         paymentMethod:
           type: string
-          enum: [cash, bank_transfer, check]
+          enum:
+            - cash
+            - card
+            - upi
+            - credit
+            - bank_transfer
+            - check
         referenceNumber:
           type: string
         notes:
@@ -2445,7 +5588,10 @@ components:
           format: date-time
     CreatePaymentRequest:
       type: object
-      required: [creditorId, amount, paymentMethod]
+      required:
+        - creditorId
+        - amount
+        - paymentMethod
       properties:
         creditorId:
           type: string
@@ -2453,7 +5599,13 @@ components:
           type: number
         paymentMethod:
           type: string
-          enum: [cash, bank_transfer, check]
+          enum:
+            - cash
+            - card
+            - upi
+            - credit
+            - bank_transfer
+            - check
         referenceNumber:
           type: string
         notes:
@@ -2522,7 +5674,10 @@ components:
           type: string
         fuelType:
           type: string
-          enum: [petrol, diesel, premium]
+          enum:
+            - petrol
+            - diesel
+            - premium
         volume:
           type: number
         deliveryDate:
@@ -2535,13 +5690,20 @@ components:
           format: date-time
     CreateFuelDeliveryRequest:
       type: object
-      required: [stationId, fuelType, volume, deliveryDate]
+      required:
+        - stationId
+        - fuelType
+        - volume
+        - deliveryDate
       properties:
         stationId:
           type: string
         fuelType:
           type: string
-          enum: [petrol, diesel, premium]
+          enum:
+            - petrol
+            - diesel
+            - premium
         volume:
           type: number
         deliveryDate:
@@ -2560,7 +5722,10 @@ components:
           type: string
         fuelType:
           type: string
-          enum: [petrol, diesel, premium]
+          enum:
+            - petrol
+            - diesel
+            - premium
         capacity:
           type: number
         currentVolume:
@@ -2577,7 +5742,10 @@ components:
           type: string
         fuelType:
           type: string
-          enum: [petrol, diesel, premium]
+          enum:
+            - petrol
+            - diesel
+            - premium
         price:
           type: number
         validFrom:
@@ -2593,13 +5761,19 @@ components:
               type: string
     CreateFuelPriceRequest:
       type: object
-      required: [stationId, fuelType, price]
+      required:
+        - stationId
+        - fuelType
+        - price
       properties:
         stationId:
           type: string
         fuelType:
           type: string
-          enum: [petrol, diesel, premium]
+          enum:
+            - petrol
+            - diesel
+            - premium
         price:
           type: number
         validFrom:
@@ -2616,16 +5790,25 @@ components:
           type: number
         fuelType:
           type: string
-          enum: [petrol, diesel, premium]
+          enum:
+            - petrol
+            - diesel
+            - premium
         status:
           type: string
-          enum: [active, inactive, maintenance]
+          enum:
+            - active
+            - inactive
+            - maintenance
         createdAt:
           type: string
           format: date-time
     CreateNozzleRequest:
       type: object
-      required: [pumpId, nozzleNumber, fuelType]
+      required:
+        - pumpId
+        - nozzleNumber
+        - fuelType
       properties:
         pumpId:
           type: string
@@ -2633,7 +5816,10 @@ components:
           type: number
         fuelType:
           type: string
-          enum: [petrol, diesel, premium]
+          enum:
+            - petrol
+            - diesel
+            - premium
     Pump:
       type: object
       properties:
@@ -2647,7 +5833,10 @@ components:
           type: string
         status:
           type: string
-          enum: [active, inactive, maintenance]
+          enum:
+            - active
+            - inactive
+            - maintenance
         createdAt:
           type: string
           format: date-time
@@ -2655,7 +5844,10 @@ components:
           type: number
     CreatePumpRequest:
       type: object
-      required: [stationId, name, serialNumber]
+      required:
+        - stationId
+        - name
+        - serialNumber
       properties:
         stationId:
           type: string
@@ -2677,7 +5869,13 @@ components:
           format: date-time
         paymentMethod:
           type: string
-          enum: [cash, card, upi, credit]
+          enum:
+            - cash
+            - card
+            - upi
+            - credit
+            - bank_transfer
+            - check
         creditorId:
           type: string
         createdAt:
@@ -2685,7 +5883,11 @@ components:
           format: date-time
     CreateReadingRequest:
       type: object
-      required: [nozzleId, reading, recordedAt, paymentMethod]
+      required:
+        - nozzleId
+        - reading
+        - recordedAt
+        - paymentMethod
       properties:
         nozzleId:
           type: string
@@ -2696,7 +5898,13 @@ components:
           format: date-time
         paymentMethod:
           type: string
-          enum: [cash, card, upi, credit]
+          enum:
+            - cash
+            - card
+            - upi
+            - credit
+            - bank_transfer
+            - check
         creditorId:
           type: string
     ReconciliationRecord:
@@ -2726,7 +5934,12 @@ components:
               type: string
     CreateReconciliationRequest:
       type: object
-      required: [stationId, date, totalExpected, cashReceived, managerConfirmation]
+      required:
+        - stationId
+        - date
+        - totalExpected
+        - cashReceived
+        - managerConfirmation
       properties:
         stationId:
           type: string
@@ -2772,7 +5985,10 @@ components:
           type: string
         fuelType:
           type: string
-          enum: [petrol, diesel, premium]
+          enum:
+            - petrol
+            - diesel
+            - premium
         volume:
           type: number
         pricePerLitre:
@@ -2781,7 +5997,13 @@ components:
           type: number
         paymentMethod:
           type: string
-          enum: [cash, card, upi, credit]
+          enum:
+            - cash
+            - card
+            - upi
+            - credit
+            - bank_transfer
+            - check
         attendant:
           type: string
         stationName:
@@ -2832,7 +6054,9 @@ components:
               type: number
     ExportReportRequest:
       type: object
-      required: [type, format]
+      required:
+        - type
+        - format
       properties:
         type:
           type: string
@@ -2851,7 +6075,9 @@ components:
               format: date-time
     ScheduleReportRequest:
       type: object
-      required: [type, frequency]
+      required:
+        - type
+        - frequency
       properties:
         type:
           type: string
@@ -2872,19 +6098,30 @@ components:
           type: number
         fuelType:
           type: string
-          enum: [petrol, diesel, premium]
+          enum:
+            - petrol
+            - diesel
+            - premium
         fuelPrice:
           type: number
         amount:
           type: number
         paymentMethod:
           type: string
-          enum: [cash, card, upi, credit]
+          enum:
+            - cash
+            - card
+            - upi
+            - credit
+            - bank_transfer
+            - check
         creditorId:
           type: string
         status:
           type: string
-          enum: [draft, posted]
+          enum:
+            - draft
+            - posted
         recordedAt:
           type: string
           format: date-time
@@ -2914,7 +6151,10 @@ components:
           type: string
         status:
           type: string
-          enum: [active, inactive, maintenance]
+          enum:
+            - active
+            - inactive
+            - maintenance
         manager:
           type: string
         attendantCount:
@@ -2955,7 +6195,10 @@ components:
                 format: date-time
               status:
                 type: string
-                enum: [active, suspended, cancelled]
+                enum:
+                  - active
+                  - suspended
+                  - cancelled
         tenantsByPlan:
           type: array
           items:
@@ -2990,7 +6233,14 @@ components:
             type: string
     CreatePlanRequest:
       type: object
-      required: [name, maxStations, maxPumpsPerStation, maxNozzlesPerPump, priceMonthly, priceYearly, features]
+      required:
+        - name
+        - maxStations
+        - maxPumpsPerStation
+        - maxNozzlesPerPump
+        - priceMonthly
+        - priceYearly
+        - features
       properties:
         name:
           type: string
@@ -3019,7 +6269,8 @@ components:
           type: string
         role:
           type: string
-          enum: [superadmin]
+          enum:
+            - superadmin
         createdAt:
           type: string
           format: date-time
@@ -3028,7 +6279,10 @@ components:
           format: date-time
     CreateAdminUserRequest:
       type: object
-      required: [name, email, password]
+      required:
+        - name
+        - email
+        - password
       properties:
         name:
           type: string
@@ -3049,7 +6303,10 @@ components:
           type: string
         status:
           type: string
-          enum: [active, suspended, cancelled]
+          enum:
+            - active
+            - suspended
+            - cancelled
         createdAt:
           type: string
           format: date-time
@@ -3059,7 +6316,9 @@ components:
           type: number
     CreateTenantRequest:
       type: object
-      required: [name, planId]
+      required:
+        - name
+        - planId
       properties:
         name:
           type: string
@@ -3080,7 +6339,11 @@ components:
           type: string
         role:
           type: string
-          enum: [superadmin, owner, manager, attendant]
+          enum:
+            - superadmin
+            - owner
+            - manager
+            - attendant
         tenantId:
           type: string
         tenantName:
@@ -3094,7 +6357,11 @@ components:
           format: date-time
     CreateUserRequest:
       type: object
-      required: [name, email, password, role]
+      required:
+        - name
+        - email
+        - password
+        - role
       properties:
         name:
           type: string
@@ -3104,7 +6371,9 @@ components:
           type: string
         role:
           type: string
-          enum: [manager, attendant]
+          enum:
+            - manager
+            - attendant
         stationId:
           type: string
     UpdateUserRequest:
@@ -3114,12 +6383,16 @@ components:
           type: string
         role:
           type: string
-          enum: [manager, attendant]
+          enum:
+            - manager
+            - attendant
         stationId:
           type: string
     ChangePasswordRequest:
       type: object
-      required: [currentPassword, newPassword]
+      required:
+        - currentPassword
+        - newPassword
       properties:
         currentPassword:
           type: string
@@ -3127,13 +6400,16 @@ components:
           type: string
     ResetPasswordRequest:
       type: object
-      required: [newPassword]
+      required:
+        - newPassword
       properties:
         newPassword:
           type: string
     CreateAlertRequest:
       type: object
-      required: [alertType, message]
+      required:
+        - alertType
+        - message
       properties:
         stationId:
           type: string
@@ -3143,7 +6419,10 @@ components:
           type: string
         severity:
           type: string
-          enum: [info, warning, critical]
+          enum:
+            - info
+            - warning
+            - critical
     FuelInventorySummary:
       type: object
       properties:
@@ -3202,6 +6481,36 @@ components:
           format: date
         status:
           type: string
-          enum: [match, over, short]
+          enum:
+            - match
+            - over
+            - short
         amount:
           type: number
+    ErrorResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        error:
+          type: string
+        details:
+          type: object
+          additionalProperties: true
+  parameters:
+    limit:
+      name: limit
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        default: 20
+      description: Number of items to return
+    offset:
+      name: offset
+      in: query
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+      description: Number of items to skip

--- a/scripts/addOperationIds.js
+++ b/scripts/addOperationIds.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const yaml = require('js-yaml');
+const doc = yaml.load(fs.readFileSync('docs/openapi.yaml', 'utf8'));
+for (const [path, methods] of Object.entries(doc.paths)) {
+  for (const [method, op] of Object.entries(methods)) {
+    if (!op || typeof op !== 'object') continue;
+    const slug = path
+      .replace(/\//g, ' ')
+      .replace(/\{(.*?)\}/g, 'By$1')
+      .split(' ')
+      .filter(Boolean)
+      .map((p, i) => i === 0 ? p : p[0].toUpperCase() + p.slice(1))
+      .join('');
+    const id = `${method}${slug.replace(/[^a-zA-Z0-9]/g, '')}`;
+    op.operationId = id;
+    // Add standard error responses if not present
+    if (!op.responses) op.responses = {};
+    for (const code of ['400','401','403','500']) {
+      if (!op.responses[code]) {
+        op.responses[code] = {
+          description: 'Error',
+          content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } }
+        };
+      }
+    }
+    // Add pagination parameters for GET list operations
+    const respSchema = op.responses['200']?.content?.['application/json']?.schema;
+    if (method === 'get' && path.match(/^\/[^{]+$/) && respSchema && respSchema.type === 'array') {
+      op.parameters = op.parameters || [];
+      const hasLimit = op.parameters.some(p=>p['$ref']==='#/components/parameters/limit');
+      if (!hasLimit) op.parameters.push({ '$ref': '#/components/parameters/limit' });
+      const hasOffset = op.parameters.some(p=>p['$ref']==='#/components/parameters/offset');
+      if (!hasOffset) op.parameters.push({ '$ref': '#/components/parameters/offset' });
+    }
+    // Add security none for auth routes
+    if (path.startsWith('/auth') || path.startsWith('/admin/auth')) {
+      op.security = [];
+    }
+  }
+}
+fs.writeFileSync('docs/openapi.yaml', yaml.dump(doc, { lineWidth: 120 }));


### PR DESCRIPTION
## Summary
- remove deprecated endpoints from OpenAPI spec
- add operationId and error responses for every operation
- unify enums and add pagination params
- update TenantAnalytics schema
- add helper script to generate operationIds
- document the fix steps and update changelog

## Testing
- `npm test --silent -- -t openapiRoutes` *(fails: docker-compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_686edbb403748320904af656ca63cfd5