### PR TITLE
Fix Reconciliation create request fields

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3214,3 +3214,10 @@ Each entry is tied to a step from the implementation index.
 * Replaced cash-based fields with `openingReading`, `closingReading` and `variance`.
 * Updated schema templates and service logic to compute readings from nozzle data.
 * `docs/STEP_fix_20260810_COMMAND.md`
+
+## [Fix 2026-08-11] – Reconciliation request cleanup
+
+### 🟥 Fixes
+* Removed obsolete cash fields from `CreateReconciliationRequest` schema.
+* Controller now expects `date` field when creating reconciliations.
+* `docs/STEP_fix_20260811_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -280,3 +280,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-08-08 | SuperAdmin analytics metrics | ✅ Done | `src/services/analytics.service.ts`, `src/controllers/analytics.controller.ts`, `docs/openapi.yaml` | `docs/STEP_fix_20260808_COMMAND.md` |
 | fix | 2026-08-09 | User updatedAt field | ✅ Done | `src/controllers/user.controller.ts`, `docs/openapi.yaml` | `docs/STEP_fix_20260809_COMMAND.md` |
 | fix | 2026-08-10 | ReconciliationRecord contract alignment | ✅ Done | `src/services/reconciliation.service.ts`, migrations | `docs/STEP_fix_20260810_COMMAND.md` |
+| fix | 2026-08-11 | Reconciliation request cleanup | ✅ Done | `src/controllers/reconciliation.controller.ts`, `docs/openapi.yaml`, `frontend/docs/openapi-v1.yaml` | `docs/STEP_fix_20260811_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1499,3 +1499,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 * Added `opening_reading`, `closing_reading` and `variance` columns.
 * Service now computes readings from nozzle data and stores them.
 * Documentation updated to reflect new response fields.
+
+### 🛠️ Fix 2026-08-11 – Reconciliation request cleanup
+**Status:** ✅ Done
+**Files:** `src/controllers/reconciliation.controller.ts`, `docs/openapi.yaml`, `frontend/docs/openapi-v1.yaml`, `docs/STEP_fix_20260811_COMMAND.md`
+
+**Overview:**
+* Removed `totalExpected` and `cashReceived` from request schema.
+* Create handler now expects a `date` field to trigger reconciliation.

--- a/docs/STEP_fix_20260811.md
+++ b/docs/STEP_fix_20260811.md
@@ -1,0 +1,14 @@
+# STEP_fix_20260811.md — ReconciliationRequest cleanup
+
+## Project Context Summary
+After shifting `ReconciliationRecord` to reading-based fields, the create request schema and controller still referenced cash totals and the `reconciliationDate` field. This caused mismatched expectations between frontend and backend.
+
+## What We Built
+- Removed `totalExpected` and `cashReceived` properties from the `CreateReconciliationRequest` schema in both OpenAPI specs.
+- Updated `reconciliation.controller.ts` to read the `date` field from the request body.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260811_COMMAND.md`

--- a/docs/STEP_fix_20260811_COMMAND.md
+++ b/docs/STEP_fix_20260811_COMMAND.md
@@ -1,0 +1,18 @@
+# STEP_fix_20260811_COMMAND.md
+## Project Context Summary
+Previous fix aligned `ReconciliationRecord` modeling to reading based fields. However `CreateReconciliationRequest` in the OpenAPI spec still used `totalExpected` and `cashReceived` which the backend no longer expects. The create handler also used `reconciliationDate` field name not reflected in the spec.
+
+## Steps Already Implemented
+- Fixes through `2026-08-10` including ReconciliationRecord contract alignment.
+
+## What to Build Now
+- Update `CreateReconciliationRequest` schema in `docs/openapi.yaml` and `frontend/docs/openapi-v1.yaml` to remove `totalExpected` and `cashReceived` and require only `stationId`, `date`, and `managerConfirmation`.
+- Update `reconciliation.controller.ts` create handler to expect `date` instead of `reconciliationDate`.
+- Document the fix in CHANGELOG, IMPLEMENTATION_INDEX, and PHASE_2_SUMMARY.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/openapi.yaml`
+- `frontend/docs/openapi-v1.yaml`

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6004,18 +6004,12 @@ components:
       required:
         - stationId
         - date
-        - totalExpected
-        - cashReceived
         - managerConfirmation
       properties:
         stationId:
           type: string
         date:
           type: string
-        totalExpected:
-          type: number
-        cashReceived:
-          type: number
         reconciliationNotes:
           type: string
         managerConfirmation:

--- a/frontend/docs/openapi-v1.yaml
+++ b/frontend/docs/openapi-v1.yaml
@@ -1783,16 +1783,12 @@ components:
               type: string
     CreateReconciliationRequest:
       type: object
-      required: [stationId, date, totalExpected, cashReceived, managerConfirmation]
+      required: [stationId, date, managerConfirmation]
       properties:
         stationId:
           type: string
         date:
           type: string
-        totalExpected:
-          type: number
-        cashReceived:
-          type: number
         reconciliationNotes:
           type: string
         managerConfirmation:

--- a/src/controllers/reconciliation.controller.ts
+++ b/src/controllers/reconciliation.controller.ts
@@ -16,15 +16,15 @@ export function createReconciliationHandlers(db: Pool) {
         if (!user?.tenantId) {
           return errorResponse(res, 400, 'Missing tenant context');
         }
-        const { stationId, reconciliationDate } = req.body || {};
-        if (!stationId || !reconciliationDate) {
-          return errorResponse(res, 400, 'stationId and reconciliationDate required');
+        const { stationId, date } = req.body || {};
+        if (!stationId || !date) {
+          return errorResponse(res, 400, 'stationId and date required');
         }
-        const date = new Date(reconciliationDate);
-        if (isNaN(date.getTime())) {
-          return errorResponse(res, 400, 'Invalid reconciliationDate');
+        const parsedDate = new Date(date);
+        if (isNaN(parsedDate.getTime())) {
+          return errorResponse(res, 400, 'Invalid date');
         }
-        const summary = await runReconciliation(db, user.tenantId, stationId, date);
+        const summary = await runReconciliation(db, user.tenantId, stationId, parsedDate);
         successResponse(res, { summary }, undefined, 201);
       } catch (err: any) {
         return errorResponse(res, 400, err.message);


### PR DESCRIPTION
## Summary
- drop `totalExpected` and `cashReceived` from CreateReconciliationRequest schema
- expect `date` in reconciliation controller create handler
- document reconciliation request cleanup

## Testing
- `npm run test:unit` *(fails: unable to provision test DB)*

------
https://chatgpt.com/codex/tasks/task_e_68723add9e1c8320aac77858a5fbc57d