### PR TITLE
Fix missing reconciliation readings columns

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3270,3 +3270,17 @@ Each entry is tied to a step from the implementation index.
 * Owners no longer require `user_stations` entries to access their tenant's stations.
 * Middleware and controllers rely on new `hasStationAccess` helper.
 * `docs/STEP_fix_20260816_COMMAND.md`
+
+## [Fix 2026-08-17] – Add reconciliation readings columns
+
+### 🟥 Fixes
+* Added migration to include `opening_reading`, `closing_reading` and `variance` in `day_reconciliations`.
+* Updated Prisma schema and regenerated client.
+* `docs/STEP_fix_20260817_COMMAND.md`
+
+## [Fix 2026-08-18] – Reconciliation documentation update
+
+### 🟦 Enhancements
+* Added `RECONCILIATION_API.md` to clarify SQL logic, variance meaning and cash difference rules.
+* Phase summary updated with documentation link.
+* `docs/STEP_fix_20260818_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -287,3 +287,5 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-08-14 | User existence check on update, inventory status fix | ✅ Done | `src/controllers/user.controller.ts`, `src/services/fuelInventory.service.ts` | `docs/STEP_fix_20260814_COMMAND.md` |
 | fix | 2026-08-15 | Station access query fix | ✅ Done | `src/controllers/dashboard.controller.ts`, `src/middlewares/checkStationAccess.ts`, `src/controllers/sales.controller.ts` | `docs/STEP_fix_20260815_COMMAND.md` |
 | fix | 2026-08-16 | Owner station access | ✅ Done | `src/middlewares/checkStationAccess.ts`, `src/controllers/dashboard.controller.ts`, `src/controllers/sales.controller.ts`, `src/utils/hasStationAccess.ts` | `docs/STEP_fix_20260816_COMMAND.md` |
+| fix | 2026-08-17 | Reconciliation readings columns | ✅ Done | `migrations/schema/012_add_day_reconciliation_readings.sql`, `prisma/schema.prisma` | `docs/STEP_fix_20260817_COMMAND.md` |
+| fix | 2026-08-18 | Reconciliation docs clarification | ✅ Done | `docs/RECONCILIATION_API.md` | `docs/STEP_fix_20260818_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1550,3 +1550,20 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * Owners automatically access stations in their tenant without `user_stations` mappings.
 * Shared helper validates access for all roles.
+
+### 🛠️ Fix 2026-08-17 – Add reconciliation readings columns
+**Status:** ✅ Done
+**Files:** `migrations/schema/012_add_day_reconciliation_readings.sql`, `prisma/schema.prisma`, `docs/STEP_fix_20260817_COMMAND.md`
+
+**Overview:**
+* Added missing fields to `day_reconciliations` table for existing databases.
+* Prisma schema aligned and client regenerated.
+
+### 🛠️ Fix 2026-08-18 – Reconciliation docs clarification
+**Status:** ✅ Done
+**Files:** `docs/RECONCILIATION_API.md`, `docs/STEP_fix_20260818_COMMAND.md`
+
+**Overview:**
+* Documented the SQL used to aggregate nozzle readings.
+* Explained the variance formula and cash difference logic.
+* Highlighted the single reconciliation per day policy and listed key endpoints.

--- a/docs/RECONCILIATION_API.md
+++ b/docs/RECONCILIATION_API.md
@@ -1,0 +1,58 @@
+# Reconciliation API Guide
+
+This document clarifies how daily reconciliation works in FuelSync Hub and lists the available endpoints.
+
+## Overview
+Each station can finalize **one** reconciliation per day. Once saved, that day is locked and new sales or payments cannot be added.
+
+## Aggregating Nozzle Readings
+The service totals opening and closing readings for all nozzles at a station using the following query:
+
+```sql
+SELECT
+  SUM(opening_reading) AS opening_reading,
+  SUM(closing_reading) AS closing_reading
+FROM (
+  SELECT MIN(nr.reading) AS opening_reading, MAX(nr.reading) AS closing_reading
+    FROM public.nozzle_readings nr
+    JOIN public.nozzles n ON nr.nozzle_id = n.id
+    JOIN public.pumps p ON n.pump_id = p.id
+   WHERE p.station_id = $1
+     AND DATE(nr.recorded_at) = $2
+     AND nr.tenant_id = $3
+   GROUP BY nr.nozzle_id
+) r;
+```
+
+This query assumes nozzle readings are monotonic and may have multiple entries per day. It selects the first and last reading per nozzle, then sums them for the station.
+
+## Variance Calculation
+After obtaining `openingReading`, `closingReading` and the day's total sales volume, the service computes:
+
+```ts
+const variance = closingReading - openingReading - totalVolume;
+```
+
+The variance represents the difference between what the nozzle readings imply was dispensed and the recorded sales. A non‑zero variance can indicate manual entry errors or missed transactions.
+
+## Cash Difference Logic
+When a cash report exists for the same day, the reported cash is compared with calculated sales totals:
+
+```ts
+const difference = reportedCash - actualCash;
+const status = difference === 0 ? 'match' : difference > 0 ? 'over' : 'short';
+```
+
+A positive difference means more cash was reported than expected (`over`), while a negative value indicates a shortage (`short`).
+
+## Key Reconciliation API Endpoints
+- `GET /reconciliation` – list reconciliations
+- `POST /reconciliation` – run reconciliation
+- `GET /reconciliation/{stationId}/{date}` – get daily summary
+- `GET /reconciliation/{id}` – get reconciliation by ID
+- `POST /reconciliation/{id}/approve` – approve and lock reconciliation
+- `GET /reconciliation/daily-summary` – per-nozzle summary
+- `GET /reconciliation/differences` – list discrepancies
+- `GET /reconciliation/differences/summary` – summary of discrepancies
+- `GET /reconciliation/differences/{id}` – get discrepancy by ID
+

--- a/docs/STEP_fix_20260817.md
+++ b/docs/STEP_fix_20260817.md
@@ -1,0 +1,15 @@
+# STEP_fix_20260817.md — Add missing reconciliation readings columns
+
+## Project Context Summary
+API calls to `/reconciliation` fail because the production database lacks the `opening_reading`, `closing_reading` and `variance` columns added in an earlier template update.
+
+## What We Built
+- Added migration `012_add_day_reconciliation_readings.sql` to add the three columns with default `0` values.
+- Updated `prisma/schema.prisma` DayReconciliation model with the new fields and regenerated Prisma client.
+- Verified the TypeScript project builds successfully.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20260817_COMMAND.md`

--- a/docs/STEP_fix_20260817_COMMAND.md
+++ b/docs/STEP_fix_20260817_COMMAND.md
@@ -1,0 +1,19 @@
+# STEP_fix_20260817_COMMAND.md
+## Project Context Summary
+A previous fix added `opening_reading`, `closing_reading` and `variance` fields to `day_reconciliations` in the schema templates. Existing databases that only ran incremental migrations lack these columns. API calls fail with `column \"opening_reading\" does not exist`.
+
+## Steps Already Implemented
+- Fixes through `2026-08-16` are recorded in `IMPLEMENTATION_INDEX.md`.
+
+## What to Build Now
+- Create new migration `migrations/schema/012_add_day_reconciliation_readings.sql` adding the three missing columns with defaults.
+- Update `prisma/schema.prisma` DayReconciliation model with `opening_reading`, `closing_reading` and `variance` fields.
+- Run `npx prisma generate` and `npm run build` to ensure compilation.
+- Document the fix in CHANGELOG, PHASE_2_SUMMARY and IMPLEMENTATION_INDEX.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20260817.md`
+- `docs/STEP_fix_20260817_COMMAND.md`

--- a/docs/STEP_fix_20260818.md
+++ b/docs/STEP_fix_20260818.md
@@ -1,0 +1,21 @@
+# STEP_fix_20260818.md — Reconciliation documentation clarifications
+
+## Project Context Summary
+Reviewers requested more clarity around the daily reconciliation process.
+SQL snippets, variance calculations and the cash difference logic were
+unclear to new contributors.
+
+## What We Built
+- Created `RECONCILIATION_API.md` detailing the reconciliation workflow and key endpoints.
+- Documented the SQL query to aggregate nozzle readings with explanatory notes.
+- Added a plain language description of the variance formula.
+- Explained how reported cash differences produce `match`, `over` or `short` statuses.
+- Emphasized the single reconciliation per station per day rule.
+- Updated changelog and phase summary with this documentation fix.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20260818_COMMAND.md`
+- `docs/RECONCILIATION_API.md`

--- a/docs/STEP_fix_20260818_COMMAND.md
+++ b/docs/STEP_fix_20260818_COMMAND.md
@@ -1,0 +1,25 @@
+# STEP_fix_20260818_COMMAND.md
+## Project Context Summary
+Feedback on the reconciliation implementation requested clearer documentation.
+The SQL logic, variance meaning, cash difference rules and locking policy
+need to be documented for new developers.
+
+## Steps Already Implemented
+- Fixes through `2026-08-17` are recorded in `IMPLEMENTATION_INDEX.md`.
+
+## What to Build Now
+- Create new guide `docs/RECONCILIATION_API.md` summarizing the reconciliation flow.
+- Explain the SQL query for opening and closing readings and note assumptions.
+- Describe the variance formula and cash discrepancy calculation.
+- List key reconciliation endpoints in bullet form.
+- Note that only one reconciliation per station per day is allowed.
+- Update `CHANGELOG.md`, `PHASE_2_SUMMARY.md` and `IMPLEMENTATION_INDEX.md`.
+- Document this step in `docs/STEP_fix_20260818.md`.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20260818.md`
+- `docs/STEP_fix_20260818_COMMAND.md`
+- `docs/RECONCILIATION_API.md`

--- a/migrations/schema/012_add_day_reconciliation_readings.sql
+++ b/migrations/schema/012_add_day_reconciliation_readings.sql
@@ -1,0 +1,7 @@
+-- Migration: 012_add_day_reconciliation_readings
+-- Description: Add missing reading fields to day_reconciliations
+
+ALTER TABLE public.day_reconciliations
+  ADD COLUMN IF NOT EXISTS opening_reading DECIMAL(10,3) DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS closing_reading DECIMAL(10,3) DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS variance DECIMAL(10,3) DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -361,6 +361,9 @@ model DayReconciliation {
   card_total   Decimal? @default(0)
   upi_total    Decimal? @default(0)
   credit_total Decimal? @default(0)
+  opening_reading Decimal? @default(0)
+  closing_reading Decimal? @default(0)
+  variance       Decimal? @default(0)
   finalized    Boolean  @default(false)
   created_at   DateTime @default(now())
   updated_at   DateTime @updatedAt


### PR DESCRIPTION
## Summary
- add migration to include opening_reading, closing_reading and variance
- update Prisma DayReconciliation model
- document fix and record new step
- expand docs with reconciliation API guide

## Testing
- `npm install`
- `npx prisma generate`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68728781732083208d14081537cab81f