### PR TITLE
Document nozzle reading void endpoint

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3298,3 +3298,10 @@ Each entry is tied to a step from the implementation index.
 * New endpoint `POST /v1/nozzle-readings/:id/void` marks readings and sales as voided.
 * Documented the process in `READING_CORRECTION_WORKFLOW.md`.
 * `docs/STEP_fix_20260820_COMMAND.md`
+
+## [Fix 2026-08-21] – OpenAPI void endpoint
+
+### 🟥 Fixes
+* Documented `POST /v1/nozzle-readings/{id}/void` in both OpenAPI specs.
+* Regenerated TypeScript API definitions.
+* `docs/STEP_fix_20260821_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -291,3 +291,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-08-18 | Reconciliation docs clarification | ✅ Done | `docs/RECONCILIATION_API.md` | `docs/STEP_fix_20260818_COMMAND.md` |
 | fix | 2026-08-19 | Nozzle lastReading field | ✅ Done | `src/services/nozzle.service.ts` | `docs/STEP_fix_20260819_COMMAND.md` |
 | fix | 2026-08-20 | Void nozzle reading workflow | ✅ Done | `migrations/schema/20250714_add_reading_audit.sql`, `src/services/nozzleReading.service.ts`, `src/controllers/nozzleReading.controller.ts`, `src/routes/nozzleReading.route.ts`, `docs/READING_CORRECTION_WORKFLOW.md` | `docs/STEP_fix_20260820_COMMAND.md` |
+| fix | 2026-08-21 | Document void reading API | ✅ Done | `docs/openapi.yaml`, `frontend/docs/openapi-v1.yaml`, `src/types/api.ts` | `docs/STEP_fix_20260821_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1574,3 +1574,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * `listNozzles` now joins the latest nozzle reading and exposes `last_reading`.
+
+### 🛠️ Fix 2026-08-21 – OpenAPI void endpoint
+**Status:** ✅ Done
+**Files:** `docs/openapi.yaml`, `frontend/docs/openapi-v1.yaml`, `src/types/api.ts`, `docs/STEP_fix_20260821_COMMAND.md`
+
+**Overview:**
+* Added missing specification for voiding nozzle readings.
+* Regenerated API type definitions.

--- a/docs/STEP_fix_20260821.md
+++ b/docs/STEP_fix_20260821.md
@@ -1,0 +1,15 @@
+# STEP_fix_20260821.md — Document void endpoint in OpenAPI
+
+## Project Context Summary
+The backend already exposes `POST /v1/nozzle-readings/:id/void` to invalidate incorrect readings. However, the OpenAPI documentation and generated types did not include this route.
+
+## What We Did
+- Added the `POST /nozzle-readings/{id}/void` operation to both OpenAPI specs.
+- Regenerated TypeScript API definitions.
+- Updated changelog, phase summary and implementation index accordingly.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260821_COMMAND.md`

--- a/docs/STEP_fix_20260821_COMMAND.md
+++ b/docs/STEP_fix_20260821_COMMAND.md
@@ -1,0 +1,21 @@
+# STEP_fix_20260821_COMMAND.md
+## Project Context Summary
+The previous fix documented the void reading workflow but the OpenAPI files were not updated. Frontend generators rely on the specification to create API hooks and types.
+
+## Steps Already Implemented
+- All fixes through `2026-08-20` are listed in `IMPLEMENTATION_INDEX.md`.
+
+## What to Build Now
+- Extend `docs/openapi.yaml` and `frontend/docs/openapi-v1.yaml` with the `POST /nozzle-readings/{id}/void` path including a `reason` body.
+- Regenerate `src/types/api.ts` using `openapi-typescript`.
+- Update changelog, phase summary and implementation index.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/openapi.yaml`
+- `frontend/docs/openapi-v1.yaml`
+- `src/types/api.ts`
+- `docs/STEP_fix_20260821.md`
+- `docs/STEP_fix_20260821_COMMAND.md`

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2332,6 +2332,60 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       operationId: putnozzlereadingsByid
+  /nozzle-readings/{id}/void:
+    post:
+      tags:
+        - Readings
+      summary: Void nozzle reading
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+              required:
+                - reason
+      responses:
+        '200':
+          description: Reading voided
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NozzleReading'
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      operationId: postnozzlereadingsByidVoid
   /reconciliation:
     get:
       tags:

--- a/frontend/docs/openapi-v1.yaml
+++ b/frontend/docs/openapi-v1.yaml
@@ -685,6 +685,35 @@ paths:
               schema:
                 $ref: '#/components/schemas/NozzleReading'
 
+  /nozzle-readings/{id}/void:
+    post:
+      tags: [Readings]
+      summary: Void nozzle reading
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+              required:
+                - reason
+      responses:
+        '200':
+          description: Reading voided
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NozzleReading'
+
   /reconciliation:
     get:
       tags: [Reconciliation]

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -715,6 +715,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/nozzle-readings/{id}/void": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Void nozzle reading */
+        post: operations["postnozzlereadingsByidVoid"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/reconciliation": {
         parameters: {
             query?: never;
@@ -5408,6 +5425,70 @@ export interface operations {
         };
         responses: {
             /** @description Nozzle reading updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NozzleReading"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    postnozzlereadingsByidVoid: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    reason: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Reading voided */
             200: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## Summary
- document `POST /nozzle-readings/{id}/void` in backend and frontend OpenAPI specs
- regenerate `src/types/api.ts`
- record fix step for documentation updates

## Testing
- `npx openapi-typescript docs/openapi.yaml -o src/types/api.ts`
- `npm run test:unit` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874dee1f6ac8320b286eb048ad21c62