### PR TITLE
Add tests for voiding readings

### DIFF
--- a/tests/nozzleReading.controller.test.ts
+++ b/tests/nozzleReading.controller.test.ts
@@ -1,0 +1,55 @@
+import { createNozzleReadingHandlers } from '../src/controllers/nozzleReading.controller';
+
+describe('nozzleReading.controller.voidReading', () => {
+  const db = { connect: jest.fn(), query: jest.fn() } as any;
+  const handlers = createNozzleReadingHandlers(db);
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('forbids attendants from voiding readings', async () => {
+    const req = {
+      user: { tenantId: 't1', userId: 'u1', role: 'attendant' },
+      params: { id: 'r1' },
+      body: { reason: 'bad' },
+    } as any;
+
+    await handlers.voidReading(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Only managers and owners can void readings',
+    });
+  });
+
+  test('allows manager to void readings', async () => {
+    (db.connect as jest.Mock).mockResolvedValue({
+      query: jest
+        .fn()
+        .mockResolvedValueOnce(undefined) // BEGIN
+        .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'r1', nozzle_id: 'n', reading: 1, recorded_at: new Date() }] })
+        .mockResolvedValueOnce({ rowCount: 0 }) // sales
+        .mockResolvedValueOnce(undefined) // audit
+        .mockResolvedValueOnce(undefined) // update reading
+        .mockResolvedValueOnce(undefined), // COMMIT
+      release: jest.fn(),
+    });
+
+    const req = {
+      user: { tenantId: 't1', userId: 'u1', role: 'manager' },
+      params: { id: 'r1' },
+      body: { reason: 'bad' },
+    } as any;
+
+    await handlers.voidReading(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: { id: 'r1', status: 'voided' } });
+  });
+});

--- a/tests/nozzleReading.service.test.ts
+++ b/tests/nozzleReading.service.test.ts
@@ -1,0 +1,33 @@
+import { voidNozzleReading } from '../src/services/nozzleReading.service';
+
+describe('voidNozzleReading', () => {
+  test('creates audit log and voids related sales', async () => {
+    const client = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce(undefined) // BEGIN
+        .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'r1', nozzle_id: 'n', reading: 1, recorded_at: new Date() }] })
+        .mockResolvedValueOnce({ rowCount: 2 }) // sales
+        .mockResolvedValueOnce(undefined) // audit log
+        .mockResolvedValueOnce(undefined) // void reading
+        .mockResolvedValueOnce(undefined) // void sales
+        .mockResolvedValueOnce(undefined), // COMMIT
+      release: jest.fn(),
+    } as any;
+
+    const db = { connect: jest.fn().mockResolvedValue(client) } as any;
+
+    const result = await voidNozzleReading(db, 't1', 'r1', 'bad', 'u1');
+
+    expect(result).toEqual({ id: 'r1', status: 'voided' });
+    expect(client.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO public.reading_audit_log'),
+      ['t1', 'r1', 'bad', 'u1']
+    );
+    expect(client.query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE public.sales SET status'),
+      ['voided', 'r1', 't1']
+    );
+    expect(client.query).toHaveBeenLastCalledWith('COMMIT');
+  });
+});


### PR DESCRIPTION
## Summary
- test controller role checks for voiding readings
- test service audit log and sales update logic

## Testing
- `npm run test:unit` *(fails: unable to provision test DB)*

------
https://chatgpt.com/codex/tasks/task_e_6874e0ee79208320ab0fe2bf199247f0