### PR TITLE
Ensure Prisma generates before start

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3305,3 +3305,10 @@ Each entry is tied to a step from the implementation index.
 * Documented `POST /v1/nozzle-readings/{id}/void` in both OpenAPI specs.
 * Regenerated TypeScript API definitions.
 * `docs/STEP_fix_20260821_COMMAND.md`
+
+## [Fix 2026-08-22] – Ensure Prisma readiness on start
+
+### 🟥 Fixes
+* Added `prestart` script to fix Prisma CLI permissions and generate the client.
+* Default server port is now `8080`.
+* `docs/STEP_fix_20260822_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -292,3 +292,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-08-19 | Nozzle lastReading field | ✅ Done | `src/services/nozzle.service.ts` | `docs/STEP_fix_20260819_COMMAND.md` |
 | fix | 2026-08-20 | Void nozzle reading workflow | ✅ Done | `migrations/schema/20250714_add_reading_audit.sql`, `src/services/nozzleReading.service.ts`, `src/controllers/nozzleReading.controller.ts`, `src/routes/nozzleReading.route.ts`, `docs/READING_CORRECTION_WORKFLOW.md` | `docs/STEP_fix_20260820_COMMAND.md` |
 | fix | 2026-08-21 | Document void reading API | ✅ Done | `docs/openapi.yaml`, `frontend/docs/openapi-v1.yaml`, `src/types/api.ts` | `docs/STEP_fix_20260821_COMMAND.md` |
+| fix | 2026-08-22 | Ensure Prisma readiness on start | ✅ Done | `package.json`, `src/app.ts` | `docs/STEP_fix_20260822_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1582,3 +1582,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * Added missing specification for voiding nozzle readings.
 * Regenerated API type definitions.
+
+### 🛠️ Fix 2026-08-22 – Ensure Prisma readiness on start
+**Status:** ✅ Done
+**Files:** `package.json`, `src/app.ts`, `docs/STEP_fix_20260822_COMMAND.md`
+
+**Overview:**
+* Added a `prestart` script that fixes Prisma CLI permissions and runs `npx prisma generate` before starting the server.
+* Default port updated to `8080`.

--- a/docs/STEP_fix_20260822.md
+++ b/docs/STEP_fix_20260822.md
@@ -1,0 +1,15 @@
+# STEP_fix_20260822.md — Start script Prisma readiness
+
+## Project Context Summary
+Azure App Service sometimes boots the Node process before Prisma generates its client. Missing execute permissions on the Prisma CLI compound the issue and the server fails to start.
+
+## What Was Done Now
+- Added a `prestart` script that fixes permissions for `node_modules/.bin/prisma` and runs `npx prisma generate`.
+- Updated the `postinstall` script with the same permission fix.
+- Changed the default server port to `8080` in `src/app.ts`.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260822_COMMAND.md`

--- a/docs/STEP_fix_20260822_COMMAND.md
+++ b/docs/STEP_fix_20260822_COMMAND.md
@@ -1,0 +1,19 @@
+# STEP_fix_20260822_COMMAND.md
+## Project Context Summary
+Deployments on Azure sometimes start the app before the Prisma client is generated. The `node_modules/.bin/prisma` file also loses execute permissions in certain containers which causes `npx prisma generate` to fail.
+
+## Steps Already Implemented
+Fixes through `2026-08-21` are logged in `IMPLEMENTATION_INDEX.md`.
+
+## What to Build Now
+- Add a `prestart` script in `package.json` to `chmod +x node_modules/.bin/prisma` and run `npx prisma generate`.
+- Update the `postinstall` script with the same permission fix.
+- Change default API port to `8080` in `src/app.ts` so the service listens on that port when `PORT` is unset.
+- Document the change in the changelog, phase summary and implementation index.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260822.md`
+- `docs/STEP_fix_20260822_COMMAND.md`

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/app.js",
   "scripts": {
     "build": "tsc",
-    "postinstall": "npx --no-install prisma generate",
+    "postinstall": "chmod +x node_modules/.bin/prisma && npx --no-install prisma generate",
+    "prestart": "chmod +x node_modules/.bin/prisma && npx prisma generate",
     "start": "node dist/src/app.js",
     "dev": "ts-node src/app.ts",
     "migrate:up": "node scripts/migrate.js up",

--- a/src/app.ts
+++ b/src/app.ts
@@ -128,7 +128,7 @@ export function createApp() {
         DB_PORT: process.env.DB_PORT || '5432',
         POSTGRES_URL: process.env.POSTGRES_URL ? 'SET' : 'NOT_SET',
         DATABASE_URL: process.env.DATABASE_URL ? 'SET' : 'NOT_SET',
-        PORT: process.env.PORT || '3003'
+        PORT: process.env.PORT || '8080'
       };
       
       // Check if we're running in Azure
@@ -258,7 +258,7 @@ export default app;
 
 // For local development
 if (require.main === module) {
-  const port = process.env.PORT || 3003;
+  const port = process.env.PORT || 8080;
   app.listen(port, () => {
     console.log(`FuelSync API listening on ${port}`);
   });


### PR DESCRIPTION
## Summary
- add `prestart` script and update `postinstall` to fix Prisma CLI permissions
- default API port to 8080
- document fix step and update summaries

## Testing
- `npm run test:unit` *(fails: unable to provision test DB)*

------
https://chatgpt.com/codex/tasks/task_e_6878a34e1ec88320a67e27b587e9fa21