### PR TITLE
Add Docker-based deployment with Prisma health check

### DIFF
--- a/.github/workflows/docker-azure.yml
+++ b/.github/workflows/docker-azure.yml
@@ -1,0 +1,31 @@
+name: Build and Deploy Docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+env:
+  AZURE_WEBAPP_NAME: fuelsync-backend
+  IMAGE_NAME: fuelsync-backend
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/docker-login@v1
+        with:
+          login-server: ${{ secrets.ACR_LOGIN_SERVER }}
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+      - name: Build and push image
+        run: |
+          docker build -t $IMAGE_NAME .
+          docker tag $IMAGE_NAME ${{ secrets.ACR_LOGIN_SERVER }}/$IMAGE_NAME:${{ github.sha }}
+          docker push ${{ secrets.ACR_LOGIN_SERVER }}/$IMAGE_NAME:${{ github.sha }}
+      - name: Deploy to Web App
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          images: ${{ secrets.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Use lightweight Node 22 base image
+FROM node:22-alpine
+
+# Create app directory
+WORKDIR /app
+
+# Copy package files and install dependencies
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Copy source code
+COPY . .
+
+# Generate Prisma client
+RUN npx prisma generate
+
+# Expose application port
+EXPOSE 8080
+
+# Start the server
+CMD ["npm", "start"]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3312,3 +3312,11 @@ Each entry is tied to a step from the implementation index.
 * Added `prestart` script to fix Prisma CLI permissions and generate the client.
 * Default server port is now `8080`.
 * `docs/STEP_fix_20260822_COMMAND.md`
+
+## [Fix 2026-08-23] – Dockerfile deployment and health check
+
+### 🟥 Fixes
+* Added Dockerfile with Node 22 Alpine and Prisma client generation.
+* Updated start scripts and created `server.js` with Prisma `/health` endpoint.
+* Introduced optional GitHub workflow for Docker deployments.
+* `docs/STEP_fix_20260823_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -293,3 +293,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-08-20 | Void nozzle reading workflow | ✅ Done | `migrations/schema/20250714_add_reading_audit.sql`, `src/services/nozzleReading.service.ts`, `src/controllers/nozzleReading.controller.ts`, `src/routes/nozzleReading.route.ts`, `docs/READING_CORRECTION_WORKFLOW.md` | `docs/STEP_fix_20260820_COMMAND.md` |
 | fix | 2026-08-21 | Document void reading API | ✅ Done | `docs/openapi.yaml`, `frontend/docs/openapi-v1.yaml`, `src/types/api.ts` | `docs/STEP_fix_20260821_COMMAND.md` |
 | fix | 2026-08-22 | Ensure Prisma readiness on start | ✅ Done | `package.json`, `src/app.ts` | `docs/STEP_fix_20260822_COMMAND.md` |
+| fix | 2026-08-23 | Dockerfile deployment and health check | ✅ Done | `Dockerfile`, `package.json`, `server.js`, `src/app.ts` | `docs/STEP_fix_20260823_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1590,3 +1590,12 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * Added a `prestart` script that fixes Prisma CLI permissions and runs `npx prisma generate` before starting the server.
 * Default port updated to `8080`.
+
+### 🛠️ Fix 2026-08-23 – Dockerfile deployment and health check
+**Status:** ✅ Done
+**Files:** `Dockerfile`, `package.json`, `server.js`, `src/app.ts`, `docs/STEP_fix_20260823_COMMAND.md`
+
+**Overview:**
+* Introduced custom Dockerfile using Node 22 Alpine with Prisma generation.
+* Start script now launches `server.js` which exposes a Prisma-based `/health` endpoint.
+* Added GitHub Actions workflow to build and deploy the container.

--- a/docs/STEP_fix_20260823.md
+++ b/docs/STEP_fix_20260823.md
@@ -1,0 +1,17 @@
+# STEP_fix_20260823.md — Docker deployment and Prisma health
+
+## Project Context Summary
+Azure deployments using Oryx caused permission issues for Prisma and mis-detected node modules. A custom Docker image removes these problems and ensures Prisma client generation before startup.
+
+## What Was Done Now
+- Added `Dockerfile` based on Node 22 Alpine that installs dependencies and runs `npx prisma generate`.
+- Updated `package.json` start and prestart scripts to use `node server.js` and generate Prisma client.
+- Created `server.js` with `/health` endpoint checking Prisma connection and default port 8080.
+- Modified `src/app.ts` health route to verify Prisma connectivity.
+- Added optional GitHub Actions workflow `docker-azure.yml` for container deployment.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260823_COMMAND.md`

--- a/docs/STEP_fix_20260823_COMMAND.md
+++ b/docs/STEP_fix_20260823_COMMAND.md
@@ -1,0 +1,21 @@
+# STEP_fix_20260823_COMMAND.md
+## Project Context Summary
+The backend must run reliably on Azure App Service using a custom Docker image. Previous deployments via Oryx caused permission errors and missing Prisma binaries. We need a Dockerfile that builds the app with Prisma and exposes port 8080. The start command should be `node server.js` and a Prisma-aware `/health` endpoint is required.
+
+## Steps Already Implemented
+Fixes through `2026-08-22` are logged in `IMPLEMENTATION_INDEX.md`.
+
+## What to Build Now
+- Create a `Dockerfile` using Node 22 Alpine that installs dependencies, runs `npx prisma generate`, and uses `CMD ["npm","start"]`.
+- Update `package.json` scripts and dependencies as required for production start with `node server.js` and Prisma generation during `postinstall`.
+- Add `server.js` entry point that listens on `process.env.PORT || 8080` and exposes a `/health` endpoint checking Prisma connection.
+- Adjust existing `/health` handler in `src/app.ts` to use Prisma.
+- Add optional GitHub Actions workflow for Docker deploy to Azure.
+- Document changes in changelog, phase summary and implementation index.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260823.md`
+- `docs/STEP_fix_20260823_COMMAND.md`

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   },
   "scripts": {
     "postinstall": "npx prisma generate",
-    "prestart": "echo Skipping prisma generate (already done at build time)",
+    "prestart": "npx prisma generate",
     "build": "tsc",
-    "start": "node dist/src/app.js",
+    "start": "node server.js",
     "dev": "ts-node src/app.ts",
     "migrate:up": "node scripts/migrate.js up",
     "migrate:down": "node scripts/migrate.js down",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,15 @@
+const app = require('./dist/src/app.js').default;
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
+
+app.get('/health', async (_req, res) => {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    res.json({ status: 'ok' });
+  } catch (err) {
+    res.status(500).json({ status: 'error', error: err.message });
+  }
+});
+
+const port = process.env.PORT || 8080;
+app.listen(port, () => console.log(`Server running on ${port}`));

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import pool from './utils/db';
+import prisma from './utils/prisma';
 import { createAuthRouter } from './routes/auth.route';
 import { createAdminAuthRouter } from './routes/adminAuth.route';
 import { createAdminApiRouter } from './routes/adminApi.router';
@@ -105,9 +106,9 @@ export function createApp() {
   // Enhanced health check endpoint with detailed diagnostics
   app.get('/health', async (_req, res) => {
     try {
-      const { testConnection } = await import('./utils/db');
-      console.log('[HEALTH] Running database connection test...');
-      const dbResult = await testConnection();
+      console.log('[HEALTH] Running Prisma connection test...');
+      await prisma.$queryRaw`SELECT 1`;
+      const dbResult = { success: true };
       
       // Get system information
       const systemInfo = {


### PR DESCRIPTION
## Summary
- add Dockerfile for Azure App Service container deployment
- update `package.json` to run `server.js` and generate Prisma client
- create `server.js` entrypoint exposing `/health`
- verify Prisma connection in Express health route
- document Docker workflow for GitHub Actions
- update docs with new fix step

## Testing
- `npm run test:unit` *(fails: unable to provision test DB)*

------
https://chatgpt.com/codex/tasks/task_e_6878b11f335883208d18f5228b43eaee