### PR TITLE
Fix Prisma CLI permission in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev
 
+# Ensure Prisma CLI is executable
+RUN chmod +x ./node_modules/.bin/prisma
+
 # Copy source code
 COPY . .
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3335,3 +3335,9 @@ Each entry is tied to a step from the implementation index.
 * Removed Docker-based workflow `docker-azure.yml`.
 * Added Node deployment workflow `azure-webapp.yml` using `azure/webapps-deploy`.
 * `docs/STEP_fix_20260825_COMMAND.md`
+
+## [Fix 2026-08-26] – Prisma CLI permission
+
+### 🟥 Fixes
+* Added `chmod +x` step in Dockerfile for Prisma binary.
+* `docs/STEP_fix_20260826_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -296,3 +296,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-08-23 | Dockerfile deployment and health check | ✅ Done | `Dockerfile`, `package.json`, `server.js`, `src/app.ts` | `docs/STEP_fix_20260823_COMMAND.md` |
 | fix | 2026-08-24 | Azure Oryx deployment cleanup | ✅ Done | `package.json`, `.github/workflows/main_fuelsync.yml` | `docs/STEP_fix_20260824_COMMAND.md` |
 | fix | 2026-08-25 | Azure WebApp deployment workflow | ✅ Done | `.github/workflows/azure-webapp.yml`, removed `docker-azure.yml` | `docs/STEP_fix_20260825_COMMAND.md` |
+| fix | 2026-08-26 | Prisma CLI permission fix | ✅ Done | `Dockerfile` | `docs/STEP_fix_20260826_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1616,3 +1616,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * Replaced container deployment with zip-based workflow using `azure/webapps-deploy`.
 * Removed obsolete `docker-azure.yml`.
+
+### 🛠️ Fix 2026-08-26 – Prisma CLI permission
+**Status:** ✅ Done
+**Files:** `Dockerfile`, `docs/STEP_fix_20260826_COMMAND.md`
+
+**Overview:**
+* Added `chmod +x` for Prisma binary during Docker build to prevent permission errors.

--- a/docs/STEP_fix_20260826.md
+++ b/docs/STEP_fix_20260826.md
@@ -1,0 +1,13 @@
+# STEP_fix_20260826.md — Docker Prisma permission
+
+## Project Context Summary
+The Azure App Service container was exiting with `sh: 1: prisma: Permission denied` during startup. The Prisma CLI lacked execute permissions in the image.
+
+## What Was Done Now
+- Added `RUN chmod +x ./node_modules/.bin/prisma` to the `Dockerfile` so Prisma commands work during build and runtime.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260826_COMMAND.md`

--- a/docs/STEP_fix_20260826_COMMAND.md
+++ b/docs/STEP_fix_20260826_COMMAND.md
@@ -1,0 +1,17 @@
+# STEP_fix_20260826_COMMAND.md
+## Project Context Summary
+Docker-based deployments to Azure App Service terminate because the Prisma CLI is not executable inside the container. The Dockerfile currently installs dependencies and runs `npx prisma generate` but does not set the executable bit for the Prisma binary.
+
+## Steps Already Implemented
+Fixes through `2026-08-25` are logged in `IMPLEMENTATION_INDEX.md`.
+
+## What to Build Now
+- Update `Dockerfile` to run `chmod +x ./node_modules/.bin/prisma` after installing dependencies.
+- Document the fix in the changelog, phase summary, and implementation index.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260826.md`
+- `docs/STEP_fix_20260826_COMMAND.md`


### PR DESCRIPTION
## Summary
- ensure Prisma CLI is executable in Dockerfile
- document the fix in project docs

## Testing
- `npm run test:unit` *(fails: unable to provision test DB)*

------
https://chatgpt.com/codex/tasks/task_e_6878bf26e7bc8320a0be6a02cea92e76