### PR TITLE
Fix CI build and deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Build and Deploy Node.js App to Azure Web App
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22.x'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma Client and Build
+        run: npm run build
+
+      - name: Zip deployment package
+        run: zip -r app.zip . -x '*.git*' 'node_modules/*' 'test/*'
+
+      - name: Deploy to Azure Web App
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: 'fuelsync'
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          package: app.zip

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3341,3 +3341,11 @@ Each entry is tied to a step from the implementation index.
 ### 🟥 Fixes
 * Added `chmod +x` step in Dockerfile for Prisma binary.
 * `docs/STEP_fix_20260826_COMMAND.md`
+
+## [Fix 2026-08-27] – CI build and deploy workflow
+
+### 🟥 Fixes
+* Removed Prisma `postinstall` script.
+* Build step runs `npx prisma generate && tsc`.
+* Added deployment workflow `deploy.yml` using `azure/webapps-deploy`.
+* `docs/STEP_fix_20260827_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -297,3 +297,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-08-24 | Azure Oryx deployment cleanup | ✅ Done | `package.json`, `.github/workflows/main_fuelsync.yml` | `docs/STEP_fix_20260824_COMMAND.md` |
 | fix | 2026-08-25 | Azure WebApp deployment workflow | ✅ Done | `.github/workflows/azure-webapp.yml`, removed `docker-azure.yml` | `docs/STEP_fix_20260825_COMMAND.md` |
 | fix | 2026-08-26 | Prisma CLI permission fix | ✅ Done | `Dockerfile` | `docs/STEP_fix_20260826_COMMAND.md` |
+| fix | 2026-08-27 | CI build Prisma generation | ✅ Done | `package.json`, `.github/workflows/deploy.yml` | `docs/STEP_fix_20260827_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1623,3 +1623,12 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Added `chmod +x` for Prisma binary during Docker build to prevent permission errors.
+
+### 🛠️ Fix 2026-08-27 – CI build and deploy workflow
+**Status:** ✅ Done
+**Files:** `package.json`, `.github/workflows/deploy.yml`, `docs/STEP_fix_20260827_COMMAND.md`
+
+**Overview:**
+* Moved Prisma client generation to the CI build step with `npm run build`.
+* Removed `postinstall` to avoid runtime permission errors.
+* New `deploy.yml` workflow zips the compiled app and deploys via `azure/webapps-deploy`.

--- a/docs/STEP_fix_20260827.md
+++ b/docs/STEP_fix_20260827.md
@@ -1,0 +1,15 @@
+# STEP_fix_20260827.md — CI build deployment
+
+## Project Context Summary
+Postinstall-based Prisma generation caused permission issues on Azure. Building and generating the client in CI avoids these runtime problems.
+
+## What Was Done Now
+- Removed `postinstall` from `package.json`.
+- Updated the `build` script to `npx prisma generate && tsc`.
+- Added `.github/workflows/deploy.yml` which builds the app and deploys it with `azure/webapps-deploy`.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260827_COMMAND.md`

--- a/docs/STEP_fix_20260827_COMMAND.md
+++ b/docs/STEP_fix_20260827_COMMAND.md
@@ -1,0 +1,20 @@
+# STEP_fix_20260827_COMMAND.md
+## Project Context Summary
+Previous fixes generated the Prisma client during `postinstall`. Azure App Service lacked the permissions for runtime generation, causing failures. We need to move Prisma generation to the build step executed in CI and simplify deployment.
+
+## Steps Already Implemented
+Fixes through `2026-08-26` are logged in `IMPLEMENTATION_INDEX.md`.
+
+## What to Build Now
+- Update `package.json`:
+  - Remove the `postinstall` script.
+  - Set the `build` script to `npx prisma generate && tsc`.
+- Add `.github/workflows/deploy.yml` that installs dependencies, runs the build, zips the app, and deploys with `azure/webapps-deploy` using a publish profile.
+- Document the update in changelog, phase summary, and implementation index.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260827.md`
+- `docs/STEP_fix_20260827_COMMAND.md`

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "postinstall": "prisma generate",
-    "build": "tsc",
+    "build": "npx prisma generate && tsc",
     "start": "node dist/src/app.js",
     "dev": "ts-node src/app.ts",
     "migrate:up": "node scripts/migrate.js up",


### PR DESCRIPTION
## Summary
- generate Prisma client in build step
- remove postinstall hook
- add GitHub Actions deploy workflow
- document CI workflow fix

## Testing
- `npm ci`
- `npm run test:unit` *(fails: unable to provision test DB)*

------
https://chatgpt.com/codex/tasks/task_e_6878c8068a98832089bd2bd3fc7f8cdc