### PR TITLE
Add DB connection debug logs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3318,3 +3318,9 @@ Each entry is tied to a step from the implementation index.
 * Configured TypeScript to compile `src/` directly into `dist/`.
 * Start script now runs `node dist/app.js`.
 * `docs/STEP_fix_20260823_COMMAND.md`
+
+## [Fix 2026-08-24] – DB connection debug logs
+
+### 🟥 Fixes
+* Added database connection test logs in the login controller to aid troubleshooting.
+* `docs/STEP_fix_20260824_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -294,3 +294,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-08-21 | Document void reading API | ✅ Done | `docs/openapi.yaml`, `frontend/docs/openapi-v1.yaml`, `src/types/api.ts` | `docs/STEP_fix_20260821_COMMAND.md` |
 | fix | 2026-08-22 | Prestart build script | ✅ Done | `package.json` | `docs/STEP_fix_20260822_COMMAND.md` |
 | fix | 2026-08-23 | Flatten build output | ✅ Done | `tsconfig.json`, `package.json` | `docs/STEP_fix_20260823_COMMAND.md` |
+| fix | 2026-08-24 | DB connection debug logs | ✅ Done | `src/controllers/auth.controller.ts` | `docs/STEP_fix_20260824_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1596,3 +1596,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Compiles TypeScript from `src/` directly into `dist/` and runs `node dist/app.js`.
+
+### 🛠️ Fix 2026-08-24 – DB connection debug logs
+**Status:** ✅ Done
+**Files:** `src/controllers/auth.controller.ts`, `docs/STEP_fix_20260824_COMMAND.md`
+
+**Overview:**
+* Added testConnection logging inside the login route to verify database connectivity on each login attempt.

--- a/docs/STEP_fix_20260824.md
+++ b/docs/STEP_fix_20260824.md
@@ -1,0 +1,15 @@
+# STEP_fix_20260824.md — DB connection debug logs
+
+## Project Context Summary
+Login attempts were failing with connection timeouts. We lacked detailed information about the database pool when these errors occurred.
+
+## What We Did
+- Imported `testConnection` into the login controller.
+- Executed the connection test on each login attempt and logged success or failure details.
+- Documented this fix in the changelog and phase summary.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260824_COMMAND.md`

--- a/docs/STEP_fix_20260824_COMMAND.md
+++ b/docs/STEP_fix_20260824_COMMAND.md
@@ -1,0 +1,18 @@
+# STEP_fix_20260824_COMMAND.md
+## Project Context Summary
+Users cannot log in on Render due to connection timeouts. Current logs show failed connections but not whether the database pool is reachable when the login request hits the server.
+
+## Steps Already Implemented
+Fixes through `2026-08-23` are recorded in `IMPLEMENTATION_INDEX.md`.
+
+## What to Build Now
+- Import `testConnection` in `src/controllers/auth.controller.ts`.
+- Call `testConnection()` at the start of the login handler and log the outcome.
+- Update documentation to reflect the new debug logs.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/STEP_fix_20260824.md`
+- `docs/STEP_fix_20260824_COMMAND.md`

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -4,6 +4,7 @@ import { login, loginSuperAdmin } from '../services/auth.service';
 import { errorResponse } from '../utils/errorResponse';
 import { successResponse } from '../utils/successResponse';
 import { JWT_SECRET, REFRESH_TOKEN_EXPIRES_IN } from '../constants/auth';
+import { testConnection } from '../utils/db';
 
 export function createAuthController(db: Pool) {
   return {
@@ -12,7 +13,22 @@ export function createAuthController(db: Pool) {
       const tenantId = req.headers['x-tenant-id'] as string | undefined;
       
       console.log(`[AUTH] Login attempt for email: ${email}, tenantId: ${tenantId || 'none'}`);
-      
+
+      try {
+        const dbCheck = await testConnection();
+        if (dbCheck.success) {
+          console.log('[AUTH] Database connection verified', {
+            time: dbCheck.time,
+            database: dbCheck.database,
+            pool: dbCheck.poolStats,
+          });
+        } else {
+          console.error('[AUTH] Database connection test failed', dbCheck);
+        }
+      } catch (connErr) {
+        console.error('[AUTH] Error testing database connection', connErr);
+      }
+
       try {
         // Check if user exists before attempting login
         let userExists = false;


### PR DESCRIPTION
## Summary
- log db connection test at login
- document new troubleshooting step

## Testing
- `npm run test:unit` *(fails: unable to provision test DB)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879fc95e3e8832091eb87c2a62f1b0c