### PR TITLE
Fix login tenant header dependency

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3324,3 +3324,10 @@ Each entry is tied to a step from the implementation index.
 ### 🟥 Fixes
 * Added database connection test logs in the login controller to aid troubleshooting.
 * `docs/STEP_fix_20260824_COMMAND.md`
+
+## [Fix 2026-08-25] – Login tenant header removal
+
+### 🟥 Fixes
+* Login no longer reads `x-tenant-id`; tenant is determined by the user's email.
+* OpenAPI updated so `/auth/login` has no tenant header requirement.
+* `docs/STEP_fix_20260825_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -295,3 +295,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-08-22 | Prestart build script | ✅ Done | `package.json` | `docs/STEP_fix_20260822_COMMAND.md` |
 | fix | 2026-08-23 | Flatten build output | ✅ Done | `tsconfig.json`, `package.json` | `docs/STEP_fix_20260823_COMMAND.md` |
 | fix | 2026-08-24 | DB connection debug logs | ✅ Done | `src/controllers/auth.controller.ts` | `docs/STEP_fix_20260824_COMMAND.md` |
+| fix | 2026-08-25 | Login tenant header removal | ✅ Done | `src/controllers/auth.controller.ts`, `src/services/auth.service.ts`, `docs/openapi.yaml` | `docs/STEP_fix_20260825_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1603,3 +1603,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Added testConnection logging inside the login route to verify database connectivity on each login attempt.
+
+### 🛠️ Fix 2026-08-25 – Login tenant header removal
+**Status:** ✅ Done
+**Files:** `src/controllers/auth.controller.ts`, `src/services/auth.service.ts`, `docs/openapi.yaml`, `docs/STEP_fix_20260825_COMMAND.md`
+
+**Overview:**
+* Login no longer expects the `x-tenant-id` header. The tenant is derived from the user's email and the OpenAPI spec was updated accordingly.

--- a/docs/STEP_fix_20260825.md
+++ b/docs/STEP_fix_20260825.md
@@ -1,0 +1,16 @@
+# STEP_fix_20260825.md — Login tenant header removal
+
+## Project Context Summary
+Login previously inspected the `x-tenant-id` header to locate a user's tenant schema. This caused confusion and failed logins when the header was missing. Emails are globally unique so the tenant can be resolved directly from the users table.
+
+## What We Did
+- Removed header lookup in the login controller.
+- Modified `login` service to query `public.users` by email when no tenant id is provided.
+- Updated `docs/openapi.yaml` so `/auth/login` no longer requires the `tenantHeader` security scheme.
+- Documented the change in the changelog and summaries.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20260825_COMMAND.md`

--- a/docs/STEP_fix_20260825_COMMAND.md
+++ b/docs/STEP_fix_20260825_COMMAND.md
@@ -1,0 +1,20 @@
+# STEP_fix_20260825_COMMAND.md
+## Project Context Summary
+The login endpoint currently reads `x-tenant-id` from headers to determine the tenant schema.
+Users reported that login should succeed without providing this header. Each email is unique in the system, so the tenant can be determined by querying the users table.
+
+## Steps Already Implemented
+- `STEP_fix_20260824_COMMAND.md` added DB connection debug logs.
+
+## What to Build Now
+- Remove the `x-tenant-id` header usage from `src/controllers/auth.controller.ts`.
+- Update `login` service in `src/services/auth.service.ts` to auto-detect the tenant by email when no tenant id is supplied.
+- Update OpenAPI spec so `/auth/login` requires no `tenantHeader`.
+- Document the new behaviour.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20260825.md`
+- `docs/STEP_fix_20260825_COMMAND.md`

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -15,6 +15,7 @@ paths:
       tags:
         - Authentication
       summary: User login
+      security: []
       requestBody:
         required: true
         content:

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -10,9 +10,8 @@ export function createAuthController(db: Pool) {
   return {
     login: async (req: Request, res: Response) => {
       const { email, password } = req.body as { email: string; password: string };
-      const tenantId = req.headers['x-tenant-id'] as string | undefined;
-      
-      console.log(`[AUTH] Login attempt for email: ${email}, tenantId: ${tenantId || 'none'}`);
+
+      console.log(`[AUTH] Login attempt for email: ${email}`);
 
       try {
         const dbCheck = await testConnection();
@@ -30,65 +29,39 @@ export function createAuthController(db: Pool) {
       }
 
       try {
-        // Check if user exists before attempting login
-        let userExists = false;
-        let foundTenantId = tenantId;
-        
-        // If no tenant ID is provided, try to find the tenant for this email
-        if (!tenantId) {
-      const adminCheck = await db.query(
-        'SELECT id, email, role FROM public.admin_users WHERE email = $1',
-        [email]
-      );
-          
-          if (adminCheck.rows.length > 0) {
-            userExists = true;
-            foundTenantId = undefined; // Admin users don't have tenant ID
-          } else {
-            // Not an admin user, try to find in tenant schemas
-            
-            const res = await db.query(
-              `SELECT u.tenant_id, t.name FROM public.users u JOIN public.tenants t ON u.tenant_id = t.id WHERE u.email = $1`,
-              [email]
-            );
-            if (res.rows.length === 1) {
-              userExists = true;
-              foundTenantId = res.rows[0].tenant_id;
-            } else if (res.rows.length > 1) {
-              console.log('[AUTH] Multiple tenants found for user, tenant header required');
-            }
-          }
+        // Determine if this is an admin user
+        const adminCheck = await db.query(
+          'SELECT id FROM public.admin_users WHERE email = $1',
+          [email]
+        );
+
+        let result;
+
+        if (adminCheck.rows.length > 0) {
+          // Super admin login
+          result = await loginSuperAdmin(db, email, password);
         } else {
-          // Tenant ID was provided, check if it exists
-          const tenantCheck = await db.query(
-            'SELECT id, name FROM public.tenants WHERE id = $1',
-            [tenantId]
+          // Look up tenant by email
+          const userRes = await db.query(
+            'SELECT tenant_id FROM public.users WHERE email = $1',
+            [email]
           );
 
-          if (tenantCheck.rows.length === 0) {
-            console.log(`[AUTH] Tenant not found: ${tenantId}`);
-            return errorResponse(res, 401, 'Tenant not found');
+          if (userRes.rows.length === 0) {
+            console.log(`[AUTH] User not found: ${email}`);
+            return errorResponse(res, 401, `User not found: ${email}`);
           }
 
-          // Check if user exists in tenant schema
-          const tenantUuid = tenantCheck.rows[0].id;
-          const userCheck = await db.query(
-            'SELECT id FROM public.users WHERE tenant_id = $1 AND email = $2',
-            [tenantUuid, email]
-          );
-
-          userExists = userCheck.rows.length > 0;
+          const tenantUuid = userRes.rows[0].tenant_id;
+          result = await login(db, email, password, tenantUuid);
         }
 
-        if (!userExists) {
-          console.log(`[AUTH] User not found: ${email} for tenant: ${foundTenantId}`);
-          return errorResponse(res, 401, `User not found: ${email}`);
+        if (!result) {
+          console.log(`[AUTH] Login failed for email: ${email} (password mismatch)`);
+          return errorResponse(res, 401, 'Invalid password');
         }
-        
-        // Attempt login with the found tenant ID
-        const result = foundTenantId ? 
-          await login(db, email, password, foundTenantId) : 
-          await login(db, email, password);
+
+        return successResponse(res, result);
         
         if (!result) {
           console.log(`[AUTH] Login failed for email: ${email} (password mismatch)`);

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -69,38 +69,72 @@ export async function login(db: Pool, email: string, password: string, tenantId?
     };
   }
 
-  // SuperAdmin login
-  console.log(`[AUTH-SERVICE] SuperAdmin login attempt for email: ${email}`);
-  
-  const res = await db.query(
+  console.log(`[AUTH-SERVICE] Login attempt without tenantId for email: ${email}`);
+
+  // Check for admin user
+  const adminRes = await db.query(
     'SELECT id, email, password_hash, role FROM public.admin_users WHERE email = $1',
     [email]
   );
-  const user = res.rows[0];
-  if (!user) {
-    console.log(`[AUTH-SERVICE] Admin user not found: ${email}`);
+  if (adminRes.rows.length > 0) {
+    const admin = adminRes.rows[0];
+    const ok = await bcrypt.compare(password, admin.password_hash);
+    if (!ok) {
+      console.log(`[AUTH-SERVICE] Password mismatch for admin user: ${email}`);
+      return null;
+    }
+
+    const payload: AuthPayload = { userId: admin.id, role: admin.role as UserRole, tenantId: null };
+    const token = generateToken(payload);
+
+    console.log(`[AUTH-SERVICE] SuperAdmin login successful for user: ${admin.id}`);
+
+    return {
+      token,
+      user: {
+        id: admin.id,
+        name: email.split('@')[0],
+        email: admin.email,
+        role: admin.role as UserRole,
+        tenantName: undefined
+      }
+    };
+  }
+
+  // Lookup regular user across tenants
+  const userRes = await db.query(
+    'SELECT id, email, password_hash, role, tenant_id FROM public.users WHERE email = $1',
+    [email]
+  );
+  if (userRes.rows.length !== 1) {
+    console.log(`[AUTH-SERVICE] User not found or not unique: ${email}`);
     return null;
   }
-  
+
+  const user = userRes.rows[0];
   const ok = await bcrypt.compare(password, user.password_hash);
   if (!ok) {
-    console.log(`[AUTH-SERVICE] Password mismatch for admin user: ${email}`);
+    console.log(`[AUTH-SERVICE] Password mismatch for user: ${email}`);
     return null;
   }
-  
-  const payload: AuthPayload = { userId: user.id, role: user.role as UserRole, tenantId: null };
+
+  const tRes = await db.query('SELECT name FROM public.tenants WHERE id = $1', [user.tenant_id]);
+  const tenantName = tRes.rows[0]?.name;
+
+  const payload: AuthPayload = { userId: user.id, tenantId: user.tenant_id, role: user.role as UserRole };
   const token = generateToken(payload);
-  
-  console.log(`[AUTH-SERVICE] SuperAdmin login successful for user: ${user.id}`);
-  
+
+  console.log(`[AUTH-SERVICE] Tenant login successful for user: ${user.id}, role: ${user.role}`);
+
   return {
     token,
     user: {
       id: user.id,
-      name: email.split('@')[0], // Use part of email as name if not available
+      name: email.split('@')[0],
       email: user.email,
       role: user.role as UserRole,
-      tenantName: undefined
+      tenantId: user.tenant_id,
+      tenantName: tenantName || undefined
     }
   };
 }


### PR DESCRIPTION
## Summary
- remove `x-tenant-id` requirement from login controller
- auto-detect tenant in auth service when no tenant id is supplied
- update OpenAPI spec to drop tenant header for `/auth/login`
- document login header removal

## Testing
- `npm ci`
- `npm run test:unit` *(fails: unable to provision test DB)*

------
https://chatgpt.com/codex/tasks/task_e_687a005b1a048320a54bece3afdf593b