### PR TITLE
Fix station ranking query alias

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3311,3 +3311,9 @@ Each entry is tied to a step from the implementation index.
 ### 🟥 Fixes
 * GitHub Actions workflow now packages only built files for Azure deployment.
 * `docs/STEP_fix_20260822_COMMAND.md`
+
+## [Fix 2026-08-23] – Station ranking alias bug
+
+### 🟥 Fixes
+* Corrected `getStationRanking` query to use base columns in ranking calculations.
+* `docs/STEP_fix_20260823_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -293,3 +293,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-08-20 | Void nozzle reading workflow | ✅ Done | `migrations/schema/20250714_add_reading_audit.sql`, `src/services/nozzleReading.service.ts`, `src/controllers/nozzleReading.controller.ts`, `src/routes/nozzleReading.route.ts`, `docs/READING_CORRECTION_WORKFLOW.md` | `docs/STEP_fix_20260820_COMMAND.md` |
 | fix | 2026-08-21 | Document void reading API | ✅ Done | `docs/openapi.yaml`, `frontend/docs/openapi-v1.yaml`, `src/types/api.ts` | `docs/STEP_fix_20260821_COMMAND.md` |
 | fix | 2026-08-22 | Azure deployment zip fix | ✅ Done | `.github/workflows/main_fuelsync.yml` | `docs/STEP_fix_20260822_COMMAND.md` |
+| fix | 2026-08-23 | Station ranking alias bug | ✅ Done | `src/services/station.service.ts` | `docs/STEP_fix_20260823_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1590,3 +1590,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Overview:**
 * Updated the CI workflow to zip only built application files for Azure deployment.
 
+
+### 🛠️ Fix 2026-08-23 – Station ranking alias bug
+**Status:** ✅ Done
+**Files:** `src/services/station.service.ts`, `docs/STEP_fix_20260823_COMMAND.md`
+
+**Overview:**
+* Station ranking query referenced an alias in the `RANK()` expression, causing a 500 error.
+* Updated the SQL to use base columns for ranking and sorting.

--- a/docs/STEP_fix_20260823.md
+++ b/docs/STEP_fix_20260823.md
@@ -1,0 +1,15 @@
+# STEP_fix_20260823.md — Station ranking query fix
+
+## Project Context Summary
+Calling `/analytics/station-ranking` resulted in a Prisma error because the SQL used an alias `total_sales` inside the `RANK()` expression. PostgreSQL cannot reference aliases there, causing a 500 response.
+
+## What We Did
+- Updated `getStationRanking` to rank and sort using the underlying `sales`, `profit` or `volume` columns.
+- Installed dependencies and built the project to verify compilation.
+- Documented the fix in the changelog, phase summary and implementation index.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20260823_COMMAND.md`

--- a/docs/STEP_fix_20260823_COMMAND.md
+++ b/docs/STEP_fix_20260823_COMMAND.md
@@ -1,0 +1,18 @@
+# STEP_fix_20260823_COMMAND.md
+## Project Context Summary
+Owners report a 500 error when calling `/analytics/station-ranking`. The backend throws a Prisma error `column "total_sales" does not exist` due to the raw SQL ranking query referencing an alias inside the `RANK()` window function.
+
+## Steps Already Implemented
+Fixes are documented through `2026-08-22`.
+
+## What to Build Now
+- Update `getStationRanking` in `src/services/station.service.ts` so the ranking expression uses base sales, profit or volume fields instead of the computed alias.
+- Run `npm install` and `npm run build` to ensure the project compiles.
+- Document the fix in `CHANGELOG.md`, `PHASE_2_SUMMARY.md` and `IMPLEMENTATION_INDEX.md`.
+- Summarize the work in `docs/STEP_fix_20260823.md`.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/STEP_fix_20260823.md`

--- a/src/services/station.service.ts
+++ b/src/services/station.service.ts
@@ -261,12 +261,12 @@ export async function getStationRanking(
   period: string
 ) {
   const interval = period === 'monthly' ? '30 days' : period === 'weekly' ? '7 days' : '1 day';
-  const orderCol =
+  const orderField =
     metric === 'profit'
-      ? Prisma.sql`total_profit`
+      ? Prisma.sql`s.profit`
       : metric === 'volume'
-      ? Prisma.sql`total_volume`
-      : Prisma.sql`total_sales`;
+      ? Prisma.sql`s.volume`
+      : Prisma.sql`s.amount`;
   const query = Prisma.sql`
     SELECT
       st.id,
@@ -275,13 +275,13 @@ export async function getStationRanking(
       COALESCE(SUM(s.profit), 0) as total_profit,
       COALESCE(SUM(s.volume), 0) as total_volume,
       COUNT(s.id) as transaction_count,
-      RANK() OVER (ORDER BY COALESCE(SUM(${orderCol}), 0) DESC) as rank
+      RANK() OVER (ORDER BY COALESCE(SUM(${orderField}), 0) DESC) as rank
     FROM stations st
     LEFT JOIN sales s ON st.id = s.station_id AND s.tenant_id = ${tenantId}
       AND s.recorded_at >= CURRENT_DATE - INTERVAL '${interval}'
     WHERE st.tenant_id = ${tenantId}
     GROUP BY st.id, st.name
-    ORDER BY ${orderCol} DESC`;
+    ORDER BY COALESCE(SUM(${orderField}), 0) DESC`;
   const rows = (await prisma.$queryRaw(query)) as any[];
   return rows.map(row => ({
     rank: parseInt(row.rank, 10),


### PR DESCRIPTION
## Summary
- fix station ranking SQL to avoid alias reference in RANK()
- document fix in changelog and phase summary
- log the step in implementation index with step files

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ab6e6c304832084a3a135b190150c