### PR TITLE
Fix failing tests and enable admin analytics route

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -15,7 +15,6 @@ paths:
       tags:
         - Authentication
       summary: User login
-      security: []
       requestBody:
         required: true
         content:

--- a/src/app.ts
+++ b/src/app.ts
@@ -23,6 +23,7 @@ import { createDashboardRouter } from './routes/dashboard.route';
 import { createInventoryRouter } from './routes/inventory.route';
 import { createReportsRouter } from './routes/reports.route';
 import { createAnalyticsRouter } from './routes/analytics.route';
+import { createAdminAnalyticsRouter } from './routes/adminAnalytics.route';
 import { createAlertsRouter } from './routes/alerts.route';
 import { createAttendantRouter } from "./routes/attendant.route";
 import { createAttendanceRouter } from "./routes/attendance.route";
@@ -201,6 +202,7 @@ export function createApp() {
   app.use(`${API_PREFIX}/auth`, createAuthRouter(pool));
   app.use(`${API_PREFIX}/admin/auth`, createAdminAuthRouter(pool));
   app.use(`${API_PREFIX}/admin`, createAdminApiRouter(pool));
+  app.use(`${API_PREFIX}/admin/analytics`, createAdminAnalyticsRouter(pool));
   app.use(`${API_PREFIX}/users`, createUserRouter(pool));
   app.use(`${API_PREFIX}/stations`, createStationRouter(pool));
   app.use(`${API_PREFIX}/pumps`, createPumpRouter(pool));

--- a/tests/analytics.service.test.ts
+++ b/tests/analytics.service.test.ts
@@ -7,9 +7,18 @@ jest.mock('../src/utils/prisma', () => ({
 
 describe('analytics.getHourlySales', () => {
   test('returns raw hourly data', async () => {
-    const rows = [{ hour: new Date(), salesVolume: 10, salesAmount: 50 }];
+    const rows = [{ hour: new Date('2023-01-01T01:00:00Z'), hour_num: 1, salesVolume: 10, salesAmount: 50, transactionCount: 5 }];
     (prisma.$queryRaw as jest.Mock).mockResolvedValue(rows);
     const result = await getHourlySales('t1', 's1', new Date('2023-01-01'), new Date('2023-01-02'));
-    expect(result).toEqual(rows);
+    expect(result).toEqual([
+      {
+        hour: 1,
+        date: '2023-01-01',
+        revenue: 50,
+        volume: 10,
+        salesCount: 5,
+        sales: 50
+      }
+    ]);
   });
 });

--- a/tests/inventory.service.test.ts
+++ b/tests/inventory.service.test.ts
@@ -9,14 +9,15 @@ describe('inventory.service.updateInventory', () => {
   test('creates alert when stock below minimum', async () => {
     const db = { query: jest.fn() } as any;
     db.query
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce({ rows: [{ current_stock: 4, minimum_level: 5 }] })
-      .mockResolvedValueOnce(undefined);
+      .mockResolvedValueOnce({ rowCount: 0 }) // check exists
+      .mockResolvedValueOnce(undefined) // insert
+      .mockResolvedValueOnce({ rows: [{ current_stock: 4, minimum_level: 5 }] }) // checkQuery
+      .mockResolvedValueOnce(undefined); // createAlert
 
     await inventoryService.updateInventory(db, 't1', 's1', 'diesel', 4);
 
-    expect(db.query).toHaveBeenCalledTimes(3);
-    expect((db.query as jest.Mock).mock.calls[2][0]).toContain('INSERT INTO public.alerts');
+    expect(db.query).toHaveBeenCalledTimes(4);
+    expect((db.query as jest.Mock).mock.calls[3][0]).toContain('INSERT INTO public.alerts');
   });
 });
 

--- a/tests/nozzleReading.controller.test.ts
+++ b/tests/nozzleReading.controller.test.ts
@@ -35,6 +35,7 @@ describe('nozzleReading.controller.voidReading', () => {
         .mockResolvedValueOnce(undefined) // BEGIN
         .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'r1', nozzle_id: 'n', reading: 1, recorded_at: new Date() }] })
         .mockResolvedValueOnce({ rowCount: 0 }) // sales
+        .mockResolvedValueOnce({ rowCount: 1 }) // user exists
         .mockResolvedValueOnce(undefined) // audit
         .mockResolvedValueOnce(undefined) // update reading
         .mockResolvedValueOnce(undefined), // COMMIT

--- a/tests/nozzleReading.service.test.ts
+++ b/tests/nozzleReading.service.test.ts
@@ -8,6 +8,7 @@ describe('voidNozzleReading', () => {
         .mockResolvedValueOnce(undefined) // BEGIN
         .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'r1', nozzle_id: 'n', reading: 1, recorded_at: new Date() }] })
         .mockResolvedValueOnce({ rowCount: 2 }) // sales
+        .mockResolvedValueOnce({ rowCount: 1 }) // user exists
         .mockResolvedValueOnce(undefined) // audit log
         .mockResolvedValueOnce(undefined) // void reading
         .mockResolvedValueOnce(undefined) // void sales


### PR DESCRIPTION
## Summary
- update tests to mock missing DB data
- remove duplicate security key from `/auth/login` in OpenAPI spec
- register `admin/analytics` router
- fix inventory, nozzle reading and analytics tests

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_687ead6321448320be61c56a7a9bdb5e