### PR TITLE
Fix nozzle reading RBAC

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3362,3 +3362,10 @@ Each entry is tied to a step from the implementation index.
 ### 🟥 Fixes
 * Inventory service now sets `updated_at` when creating or updating records.
 * `docs/STEP_fix_20260827_COMMAND.md`
+
+## [Fix 2026-08-28] – Nozzle reading role enforcement
+
+### 🟥 Fixes
+* Added `requireRole` middleware to all nozzle reading routes.
+* Documented allowed roles in OpenAPI via `x-roles` extension and regenerated API types.
+* `docs/STEP_fix_20260828_COMMAND.md`

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -301,3 +301,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2026-08-22 | Azure deployment zip fix | ✅ Done | `.github/workflows/main_fuelsync.yml` | `docs/STEP_fix_20260822_COMMAND.md` |
 | fix | 2026-08-23 | Station ranking alias bug | ✅ Done | `src/services/station.service.ts` | `docs/STEP_fix_20260823_COMMAND.md` |
 | fix | 2026-08-27 | Inventory updated_at bug | ✅ Done | `src/services/inventory.service.ts` | `docs/STEP_fix_20260827_COMMAND.md` |
+| fix | 2026-08-28 | Nozzle reading role enforcement | ✅ Done | `src/routes/nozzleReading.route.ts`, `docs/openapi.yaml`, `frontend/docs/openapi-v1.yaml`, `src/types/api.ts` | `docs/STEP_fix_20260828_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1648,3 +1648,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 **Overview:**
 * Inventory update queries now set the `updated_at` timestamp to avoid null constraint errors.
+
+### 🛠️ Fix 2026-08-28 – Nozzle reading role enforcement
+**Status:** ✅ Done
+**Files:** `src/routes/nozzleReading.route.ts`, `docs/openapi.yaml`, `frontend/docs/openapi-v1.yaml`, `src/types/api.ts`, `docs/STEP_fix_20260828_COMMAND.md`
+
+**Overview:**
+* Applied role middleware to nozzle reading routes and documented roles in the API specification.

--- a/docs/STEP_fix_20260828.md
+++ b/docs/STEP_fix_20260828.md
@@ -1,0 +1,19 @@
+# STEP_fix_20260828.md — Explicit nozzle reading RBAC and docs
+
+## Project Context Summary
+Nozzle reading endpoints previously relied solely on authentication. Role-based restrictions were checked only in controllers for update and void. OpenAPI documentation lacked any role hints.
+
+## What We Did
+- Applied `requireRole` middleware in `nozzleReading.route.ts` for all routes.
+- Annotated nozzle reading operations in the OpenAPI specs with `x-roles` lists.
+- Regenerated TypeScript API types.
+- Updated changelog, implementation index and phase summary.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/openapi.yaml`
+- `frontend/docs/openapi-v1.yaml`
+- `src/types/api.ts`
+- `docs/STEP_fix_20260828_COMMAND.md`

--- a/docs/STEP_fix_20260828_COMMAND.md
+++ b/docs/STEP_fix_20260828_COMMAND.md
@@ -1,0 +1,24 @@
+# STEP_fix_20260828_COMMAND.md
+## Project Context Summary
+Recent audits showed that nozzle reading routes lacked explicit role checks and the OpenAPI spec does not document role access. Previous fixes through 2026-08-27 are logged in `IMPLEMENTATION_INDEX.md`.
+
+## Steps Already Implemented
+- Backend routes exist for creating, listing, updating and voiding nozzle readings.
+- `requireRole` middleware is available for enforcing RBAC.
+- OpenAPI docs cover all operations but omit role annotations.
+
+## What to Build Now
+- Update `src/routes/nozzleReading.route.ts` to enforce roles on all routes. Creation, list, get and can-create should allow owner, manager and attendant. Update and void remain manager/owner only.
+- Add `x-roles` arrays to nozzle reading operations in `docs/openapi.yaml` and `frontend/docs/openapi-v1.yaml`.
+- Regenerate `src/types/api.ts` using `openapi-typescript`.
+- Document the changes in changelog, implementation index and phase summary.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/IMPLEMENTATION_INDEX.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/openapi.yaml`
+- `frontend/docs/openapi-v1.yaml`
+- `src/types/api.ts`
+- `docs/STEP_fix_20260828.md`
+- `docs/STEP_fix_20260828_COMMAND.md`

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2160,6 +2160,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       operationId: getnozzlereadings
+      x-roles:
+        - owner
+        - manager
+        - attendant
     post:
       tags:
         - Readings
@@ -2202,6 +2206,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       operationId: postnozzlereadings
+      x-roles:
+        - owner
+        - manager
+        - attendant
   /nozzle-readings/can-create/{nozzleId}:
     get:
       tags:
@@ -2241,6 +2249,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       operationId: getnozzlereadingsCancreateBynozzleId
+      x-roles:
+        - owner
+        - manager
+        - attendant
   /nozzle-readings/{id}:
     get:
       tags:
@@ -2284,6 +2296,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       operationId: getnozzlereadingsByid
+      x-roles:
+        - owner
+        - manager
+        - attendant
     put:
       tags:
         - Readings
@@ -2332,6 +2348,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       operationId: putnozzlereadingsByid
+      x-roles:
+        - owner
+        - manager
   /nozzle-readings/{id}/void:
     post:
       tags:
@@ -2386,6 +2405,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       operationId: postnozzlereadingsByidVoid
+      x-roles:
+        - owner
+        - manager
   /reconciliation:
     get:
       tags:

--- a/frontend/docs/openapi-v1.yaml
+++ b/frontend/docs/openapi-v1.yaml
@@ -2161,6 +2161,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       operationId: getnozzlereadings
+      x-roles:
+        - owner
+        - manager
+        - attendant
     post:
       tags:
         - Readings
@@ -2203,6 +2207,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       operationId: postnozzlereadings
+      x-roles:
+        - owner
+        - manager
+        - attendant
   /nozzle-readings/can-create/{nozzleId}:
     get:
       tags:
@@ -2242,6 +2250,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       operationId: getnozzlereadingsCancreateBynozzleId
+      x-roles:
+        - owner
+        - manager
+        - attendant
   /nozzle-readings/{id}:
     get:
       tags:
@@ -2285,6 +2297,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       operationId: getnozzlereadingsByid
+      x-roles:
+        - owner
+        - manager
+        - attendant
     put:
       tags:
         - Readings
@@ -2333,6 +2349,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       operationId: putnozzlereadingsByid
+      x-roles:
+        - owner
+        - manager
   /nozzle-readings/{id}/void:
     post:
       tags:
@@ -2387,6 +2406,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       operationId: postnozzlereadingsByidVoid
+      x-roles:
+        - owner
+        - manager
   /reconciliation:
     get:
       tags:

--- a/src/routes/nozzleReading.route.ts
+++ b/src/routes/nozzleReading.route.ts
@@ -2,20 +2,58 @@ import { Router } from 'express';
 import { Pool } from 'pg';
 import { authenticateJWT } from '../middlewares/authenticateJWT';
 import { setTenantContext } from '../middlewares/setTenantContext';
+import { requireRole } from '../middlewares/requireRole';
+import { UserRole } from '../constants/auth';
 import { createNozzleReadingHandlers } from '../controllers/nozzleReading.controller';
 
 export function createNozzleReadingRouter(db: Pool) {
   const router = Router();
   const handlers = createNozzleReadingHandlers(db);
 
-  router.post('/', authenticateJWT, setTenantContext, handlers.create);
-  router.get('/', authenticateJWT, setTenantContext, handlers.list);
-  router.get('/can-create/:nozzleId', authenticateJWT, setTenantContext, handlers.canCreate);
-  router.get('/:id', authenticateJWT, setTenantContext, handlers.get);
-  router.put('/:id', authenticateJWT, setTenantContext, handlers.update);
+  router.post(
+    '/',
+    authenticateJWT,
+    setTenantContext,
+    requireRole([UserRole.Owner, UserRole.Manager, UserRole.Attendant]),
+    handlers.create
+  );
+  router.get(
+    '/',
+    authenticateJWT,
+    setTenantContext,
+    requireRole([UserRole.Owner, UserRole.Manager, UserRole.Attendant]),
+    handlers.list
+  );
+  router.get(
+    '/can-create/:nozzleId',
+    authenticateJWT,
+    setTenantContext,
+    requireRole([UserRole.Owner, UserRole.Manager, UserRole.Attendant]),
+    handlers.canCreate
+  );
+  router.get(
+    '/:id',
+    authenticateJWT,
+    setTenantContext,
+    requireRole([UserRole.Owner, UserRole.Manager, UserRole.Attendant]),
+    handlers.get
+  );
+  router.put(
+    '/:id',
+    authenticateJWT,
+    setTenantContext,
+    requireRole([UserRole.Owner, UserRole.Manager]),
+    handlers.update
+  );
   
   // Add void endpoint
-  router.post('/:id/void', authenticateJWT, setTenantContext, handlers.voidReading);
+  router.post(
+    '/:id/void',
+    authenticateJWT,
+    setTenantContext,
+    requireRole([UserRole.Owner, UserRole.Manager]),
+    handlers.voidReading
+  );
 
   return router;
 }


### PR DESCRIPTION
## Summary
- enforce role checks in nozzle reading routes
- document allowed roles in OpenAPI with new `x-roles` extension
- regenerate API types
- record changes in docs

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687f4463af98832082af2cfd76955a62