### PR TITLE
Fix todays sales query

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3451,3 +3451,9 @@ Each entry is tied to a step from the implementation index.
 * Generated updated TypeScript API types.
 * Added integration test for RBAC on the new endpoint.
 * `docs/STEP_2_61_COMMAND.md`
+## [Fix 2025-07-25] – Today's sales summary query
+
+### 🟥 Fixes
+* Aggregated daily sales data from the `sales` table instead of `nozzle_readings` to match the unified schema.
+* `docs/STEP_fix_20250725_COMMAND.md`
+

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -313,3 +313,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 2     | 2.59 | Reconciliation finalization helpers | ✅ Done | `src/services/reconciliation.service.ts`, `src/services/nozzleReading.service.ts`, `src/services/attendant.service.ts`, `migrations/schema/013_prevent_finalized_writes.sql` | `PHASE_2_SUMMARY.md#step-2.59` |
 | 2     | 2.60 | Reconciliation station validation | ✅ Done | `src/utils/hasStationAccess.ts`, `src/services/reconciliation.service.ts`, `src/controllers/reconciliation.controller.ts`, `tests/reconciliation.service.test.ts` | `PHASE_2_SUMMARY.md#step-2.60` |
 | 2     | 2.61 | Today's sales summary endpoint | ✅ Done | `docs/openapi.yaml`, `frontend/docs/openapi-v1.yaml`, `src/types/api.ts`, `tests/integration/todaysSales.test.ts` | `PHASE_2_SUMMARY.md#step-2.61` |
+| fix | 2025-07-25 | Today's sales summary query | ✅ Done | `src/services/todaysSales.service.ts` | `docs/STEP_fix_20250725_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1721,4 +1721,10 @@ sudo apt-get update && sudo apt-get install -y postgresql
 **Status:** ✅ Done
 **Files:** `src/controllers/todaysSales.controller.ts`, `src/routes/todaysSales.route.ts`, `src/services/todaysSales.service.ts`, `docs/openapi.yaml`, `frontend/docs/openapi-v1.yaml`, `src/types/api.ts`, `tests/integration/todaysSales.test.ts`, `docs/STEP_2_61_COMMAND.md`
 
+
 **Overview:** Documented and tested the new `/todays-sales/summary` endpoint which returns a consolidated sales snapshot for the selected date. OpenAPI specs now describe the response schemas and allowed roles. API types were regenerated and integration tests verify RBAC behaviour.
+### 🛠️ Fix 2025-07-25 – Today's sales summary query
+**Status:** ✅ Done
+**Files:** `src/services/todaysSales.service.ts`, `docs/STEP_fix_20250725_COMMAND.md`
+
+**Overview:** Updated the service to read from the `sales` table so the endpoint works with the unified schema.

--- a/docs/STEP_fix_20250725_COMMAND.md
+++ b/docs/STEP_fix_20250725_COMMAND.md
@@ -1,0 +1,17 @@
+# STEP_fix_20250725_COMMAND.md
+
+## Project Context Summary
+FuelSync Hub is a multi-tenant ERP platform. Backend implementation up to Step 2.61 introduced `/todays-sales/summary` to provide a daily sales snapshot. During local testing this endpoint failed because the service queried the legacy `nozzle_readings` table which no longer contains `volume` and `amount` columns in the unified schema.
+
+## Steps Already Implemented
+- Up to `docs/STEP_2_61_COMMAND.md` and subsequent fix steps in December 2025.
+
+## What to Build Now
+- Update `src/services/todaysSales.service.ts` to aggregate data from `sales` instead of `nozzle_readings`.
+- Ensure all integration and unit tests pass (`npm run test:unit`).
+- Document the fix in CHANGELOG, PHASE_2_SUMMARY and IMPLEMENTATION_INDEX.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`

--- a/src/services/todaysSales.service.ts
+++ b/src/services/todaysSales.service.ts
@@ -73,27 +73,27 @@ export async function getTodaysSalesSummary(
   
   console.log('[TODAYS-SALES-SERVICE] Starting query for tenant:', tenantId, 'date:', dateStr);
 
-  // Get overall summary - using nozzle_readings table which is the actual source
+  // Get overall summary - using sales table which contains volume and amount
   const summaryQuery = `
-    SELECT 
+    SELECT
       COUNT(*) as total_entries,
-      COALESCE(SUM(nr.volume), 0) as total_volume,
-      COALESCE(SUM(nr.amount), 0) as total_amount,
-      COALESCE(SUM(CASE WHEN nr.payment_method = 'cash' THEN nr.amount ELSE 0 END), 0) as cash_amount,
-      COALESCE(SUM(CASE WHEN nr.payment_method = 'card' THEN nr.amount ELSE 0 END), 0) as card_amount,
-      COALESCE(SUM(CASE WHEN nr.payment_method = 'upi' THEN nr.amount ELSE 0 END), 0) as upi_amount,
-      COALESCE(SUM(CASE WHEN nr.payment_method = 'credit' THEN nr.amount ELSE 0 END), 0) as credit_amount
-    FROM public.nozzle_readings nr
-    JOIN public.nozzles n ON nr.nozzle_id = n.id
+      COALESCE(SUM(sl.volume), 0) as total_volume,
+      COALESCE(SUM(sl.amount), 0) as total_amount,
+      COALESCE(SUM(CASE WHEN sl.payment_method = 'cash' THEN sl.amount ELSE 0 END), 0) as cash_amount,
+      COALESCE(SUM(CASE WHEN sl.payment_method = 'card' THEN sl.amount ELSE 0 END), 0) as card_amount,
+      COALESCE(SUM(CASE WHEN sl.payment_method = 'upi' THEN sl.amount ELSE 0 END), 0) as upi_amount,
+      COALESCE(SUM(CASE WHEN sl.payment_method = 'credit' THEN sl.amount ELSE 0 END), 0) as credit_amount
+    FROM public.sales sl
+    JOIN public.nozzles n ON sl.nozzle_id = n.id
     JOIN public.pumps p ON n.pump_id = p.id
     JOIN public.stations st ON p.station_id = st.id
-    WHERE DATE(nr.recorded_at AT TIME ZONE 'UTC') = $1 
-      AND nr.tenant_id = $2
+    WHERE DATE(sl.recorded_at AT TIME ZONE 'UTC') = $1
+      AND sl.tenant_id = $2
   `;
 
   // Get nozzle-wise entries
   const nozzleEntriesQuery = `
-    SELECT 
+    SELECT
       n.id as nozzle_id,
       n.nozzle_number,
       n.fuel_type,
@@ -101,87 +101,87 @@ export async function getTodaysSalesSummary(
       p.name as pump_name,
       st.id as station_id,
       st.name as station_name,
-      COUNT(nr.id) as entries_count,
-      COALESCE(SUM(nr.volume), 0) as total_volume,
-      COALESCE(SUM(nr.amount), 0) as total_amount,
-      MAX(nr.recorded_at) as last_entry_time,
-      CASE 
-        WHEN COUNT(nr.id) > 0 THEN COALESCE(SUM(nr.amount), 0) / COUNT(nr.id)
-        ELSE 0 
+      COUNT(sl.id) as entries_count,
+      COALESCE(SUM(sl.volume), 0) as total_volume,
+      COALESCE(SUM(sl.amount), 0) as total_amount,
+      MAX(sl.recorded_at) as last_entry_time,
+      CASE
+        WHEN COUNT(sl.id) > 0 THEN COALESCE(SUM(sl.amount), 0) / COUNT(sl.id)
+        ELSE 0
       END as average_ticket_size
     FROM public.nozzles n
     JOIN public.pumps p ON n.pump_id = p.id
     JOIN public.stations st ON p.station_id = st.id
-    LEFT JOIN public.nozzle_readings nr ON n.id = nr.nozzle_id 
-      AND DATE(nr.recorded_at AT TIME ZONE 'UTC') = $1 
-      AND nr.tenant_id = $2
+    LEFT JOIN public.sales sl ON n.id = sl.nozzle_id
+      AND DATE(sl.recorded_at AT TIME ZONE 'UTC') = $1
+      AND sl.tenant_id = $2
     WHERE st.tenant_id = $2
     GROUP BY n.id, n.nozzle_number, n.fuel_type, p.id, p.name, st.id, st.name
-    HAVING COUNT(nr.id) > 0
+    HAVING COUNT(sl.id) > 0
     ORDER BY total_amount DESC, st.name, p.name, n.nozzle_number
   `;
 
   // Get sales by fuel type
   const fuelBreakdownQuery = `
-    SELECT 
+    SELECT
       n.fuel_type,
-      COALESCE(SUM(nr.volume), 0) as total_volume,
-      COALESCE(SUM(nr.amount), 0) as total_amount,
-      COUNT(nr.id) as entries_count,
-      CASE 
-        WHEN SUM(nr.volume) > 0 THEN SUM(nr.amount) / SUM(nr.volume)
-        ELSE 0 
+      COALESCE(SUM(sl.volume), 0) as total_volume,
+      COALESCE(SUM(sl.amount), 0) as total_amount,
+      COUNT(sl.id) as entries_count,
+      CASE
+        WHEN SUM(sl.volume) > 0 THEN SUM(sl.amount) / SUM(sl.volume)
+        ELSE 0
       END as average_price,
       COUNT(DISTINCT st.id) as stations_count
-    FROM public.nozzle_readings nr
-    JOIN public.nozzles n ON nr.nozzle_id = n.id
+    FROM public.sales sl
+    JOIN public.nozzles n ON sl.nozzle_id = n.id
     JOIN public.pumps p ON n.pump_id = p.id
     JOIN public.stations st ON p.station_id = st.id
-    WHERE DATE(nr.recorded_at AT TIME ZONE 'UTC') = $1 
-      AND nr.tenant_id = $2
+    WHERE DATE(sl.recorded_at AT TIME ZONE 'UTC') = $1
+      AND sl.tenant_id = $2
     GROUP BY n.fuel_type
     ORDER BY total_amount DESC
   `;
 
   // Get sales by station
   const stationBreakdownQuery = `
-    SELECT 
+    SELECT
       st.id as station_id,
       st.name as station_name,
-      COALESCE(SUM(nr.volume), 0) as total_volume,
-      COALESCE(SUM(nr.amount), 0) as total_amount,
-      COUNT(nr.id) as entries_count,
+      COALESCE(SUM(sl.volume), 0) as total_volume,
+      COALESCE(SUM(sl.amount), 0) as total_amount,
+      COUNT(sl.id) as entries_count,
       array_agg(DISTINCT n.fuel_type) as fuel_types,
       COUNT(DISTINCT n.id) as nozzles_active,
-      MAX(nr.recorded_at) as last_activity
-    FROM public.nozzle_readings nr
-    JOIN public.nozzles n ON nr.nozzle_id = n.id
+      MAX(sl.recorded_at) as last_activity
+    FROM public.sales sl
+    JOIN public.nozzles n ON sl.nozzle_id = n.id
     JOIN public.pumps p ON n.pump_id = p.id
     JOIN public.stations st ON p.station_id = st.id
-    WHERE DATE(nr.recorded_at AT TIME ZONE 'UTC') = $1 
-      AND nr.tenant_id = $2
+    WHERE DATE(sl.recorded_at AT TIME ZONE 'UTC') = $1
+      AND sl.tenant_id = $2
     GROUP BY st.id, st.name
     ORDER BY total_amount DESC
   `;
 
   // Get credit sales
   const creditSalesQuery = `
-    SELECT 
+    SELECT
       c.id as creditor_id,
       c.party_name as creditor_name,
       st.id as station_id,
       st.name as station_name,
-      COALESCE(SUM(nr.amount), 0) as total_amount,
-      COUNT(nr.id) as entries_count,
-      MAX(nr.recorded_at) as last_credit_time
-    FROM public.nozzle_readings nr
-    JOIN public.nozzles n ON nr.nozzle_id = n.id
+      COALESCE(SUM(sl.amount), 0) as total_amount,
+      COUNT(sl.id) as entries_count,
+      MAX(sl.recorded_at) as last_credit_time
+    FROM public.sales sl
+    JOIN public.nozzles n ON sl.nozzle_id = n.id
     JOIN public.pumps p ON n.pump_id = p.id
     JOIN public.stations st ON p.station_id = st.id
-    LEFT JOIN public.creditors c ON nr.creditor_id = c.id
-    WHERE DATE(nr.recorded_at AT TIME ZONE 'UTC') = $1 
-      AND nr.tenant_id = $2
-      AND nr.payment_method = 'credit'
+    LEFT JOIN public.creditors c ON sl.creditor_id = c.id
+    WHERE DATE(sl.recorded_at AT TIME ZONE 'UTC') = $1
+      AND sl.tenant_id = $2
+      AND sl.payment_method = 'credit'
       AND c.id IS NOT NULL
     GROUP BY c.id, c.party_name, st.id, st.name
     ORDER BY total_amount DESC


### PR DESCRIPTION
## Summary
- query `/todays-sales/summary` from `sales` table instead of `nozzle_readings`
- document today's sales query fix

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68831ab2aa108320922a76290d933285