### PR TITLE
Add comprehensive API journey diagrams

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3485,6 +3485,16 @@ Each entry is tied to a step from the implementation index.
 * Generated updated TypeScript API types.
 * Added integration test for RBAC on the new endpoint.
 * `docs/STEP_2_61_COMMAND.md`
+## [Step 2.62] – API user journey diagrams
+
+### 🟦 Documentation
+* Added `docs/journeys/USER_API_FLOW.md` illustrating station setup and reading workflows using Mermaid diagrams.
+* `docs/STEP_2_62_COMMAND.md`
+## [Step 2.63] – Expanded user journey diagrams
+
+### 🟦 Documentation
+* Enhanced `docs/journeys/USER_API_FLOW.md` with sales calculation, validation edge cases, analytics flow and an ER diagram linking key tables.
+* `docs/STEP_2_63_COMMAND.md`
 ## [Fix 2025-07-25] – Today's sales summary query
 
 ### 🟥 Fixes

--- a/docs/IMPLEMENTATION_INDEX.md
+++ b/docs/IMPLEMENTATION_INDEX.md
@@ -318,6 +318,8 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 2     | 2.59 | Reconciliation finalization helpers | ✅ Done | `src/services/reconciliation.service.ts`, `src/services/nozzleReading.service.ts`, `src/services/attendant.service.ts`, `migrations/schema/013_prevent_finalized_writes.sql` | `PHASE_2_SUMMARY.md#step-2.59` |
 | 2     | 2.60 | Reconciliation station validation | ✅ Done | `src/utils/hasStationAccess.ts`, `src/services/reconciliation.service.ts`, `src/controllers/reconciliation.controller.ts`, `tests/reconciliation.service.test.ts` | `PHASE_2_SUMMARY.md#step-2.60` |
 | 2     | 2.61 | Today's sales summary endpoint | ✅ Done | `docs/openapi.yaml`, `frontend/docs/openapi-v1.yaml`, `src/types/api.ts`, `tests/integration/todaysSales.test.ts` | `PHASE_2_SUMMARY.md#step-2.61` |
+| 2     | 2.62 | API user journey diagrams | ✅ Done | `docs/journeys/USER_API_FLOW.md` | `PHASE_2_SUMMARY.md#step-2.62` |
+| 2     | 2.63 | Expanded user journey diagrams | ✅ Done | `docs/journeys/USER_API_FLOW.md` | `PHASE_2_SUMMARY.md#step-2.63` |
 | fix | 2025-07-25 | Today's sales summary query | ✅ Done | `src/services/todaysSales.service.ts` | `docs/STEP_fix_20250725_COMMAND.md` |
 | fix | 2025-07-26 | Azure master deployment branch | ✅ Done | `.github/workflows/main_fuelsync.yml` | `docs/STEP_fix_20250726_COMMAND.md` |
 | fix | 2025-07-27 | Restore sales aggregation | ✅ Done | `src/services/todaysSales.service.ts` | `docs/STEP_fix_20250727_COMMAND.md` |

--- a/docs/PHASE_2_SUMMARY.md
+++ b/docs/PHASE_2_SUMMARY.md
@@ -1751,6 +1751,16 @@ sudo apt-get update && sudo apt-get install -y postgresql
 
 
 **Overview:** Documented and tested the new `/todays-sales/summary` endpoint which returns a consolidated sales snapshot for the selected date. OpenAPI specs now describe the response schemas and allowed roles. API types were regenerated and integration tests verify RBAC behaviour.
+### 🛠️ Step 2.62 – API user journey diagrams
+**Status:** ✅ Done
+**Files:** `docs/journeys/USER_API_FLOW.md`, `docs/STEP_2_62_COMMAND.md`
+
+**Overview:** Added mermaid diagrams demonstrating how owners/managers set up stations, pumps, nozzles and fuel prices, followed by attendants recording nozzle readings. These diagrams clarify the end-to-end API flow.
+### 🛠️ Step 2.63 – Expanded user journey diagrams
+**Status:** ✅ Done
+**Files:** `docs/journeys/USER_API_FLOW.md`, `docs/STEP_2_63_COMMAND.md`
+
+**Overview:** Extended the diagrams to show sale calculation logic, validation edge cases, analytics and reconciliation flow, plus an ER diagram linking key tables.
 ### 🛠️ Fix 2025-07-25 – Today's sales summary query
 **Status:** ✅ Done
 **Files:** `src/services/todaysSales.service.ts`, `docs/STEP_fix_20250725_COMMAND.md`

--- a/docs/STEP_2_62_COMMAND.md
+++ b/docs/STEP_2_62_COMMAND.md
@@ -1,0 +1,19 @@
+# STEP_2_62_COMMAND.md
+## Project Context Summary
+FuelSync Hub is a multi-tenant ERP for fuel stations. Backend development is complete up to **Step 2.61** which added the `todays-sales` summary endpoint. Documentation covers APIs and workflows but lacks a visual overview of the station setup and daily reading process.
+
+## Steps Already Implemented
+- All CRUD APIs for stations, pumps, nozzles, fuel prices and nozzle readings.
+- Documentation through `Step 2.61` and various fix steps.
+
+## What to Build Now
+- Create a new documentation file `docs/journeys/USER_API_FLOW.md` containing Mermaid diagrams that illustrate:
+  - Owner/Manager setting up a station, pumps, nozzles and fuel prices.
+  - Attendant entering daily nozzle readings.
+- Diagrams must reference exact API routes such as `/api/v1/stations` and `/api/v1/nozzle-readings`.
+- Update `CHANGELOG.md`, `PHASE_2_SUMMARY.md` and `IMPLEMENTATION_INDEX.md` to record this documentation step.
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`

--- a/docs/STEP_2_63_COMMAND.md
+++ b/docs/STEP_2_63_COMMAND.md
@@ -1,0 +1,20 @@
+# STEP_2_63_COMMAND.md
+## Project Context Summary
+FuelSync Hub is a multi-tenant ERP for fuel stations. Up through **Step 2.62** the documentation included basic Mermaid diagrams of station setup and daily readings. Users requested a more comprehensive view including sales calculation, validation edge cases, analytics flow and database relationships.
+
+## Steps Already Implemented
+- CRUD APIs for all domain entities
+- Mermaid diagrams showing simple setup and reading flows (Step 2.62)
+
+## What to Build Now
+- Expand `docs/journeys/USER_API_FLOW.md` to cover:
+  - Sale calculation using nozzle delta and fuel prices
+  - Validation edge cases when prices are missing or previous day not finalized
+  - How reconciliation feeds analytics
+  - An ER diagram connecting tables (stations, pumps, nozzles, readings, sales, recon)
+- Update `CHANGELOG.md`, `PHASE_2_SUMMARY.md` and `IMPLEMENTATION_INDEX.md` for Step 2.63
+
+## Required Documentation Updates
+- `docs/CHANGELOG.md`
+- `docs/PHASE_2_SUMMARY.md`
+- `docs/IMPLEMENTATION_INDEX.md`

--- a/docs/journeys/USER_API_FLOW.md
+++ b/docs/journeys/USER_API_FLOW.md
@@ -1,0 +1,72 @@
+# USER_API_FLOW.md — Station Setup & Daily Operations
+
+This document visualizes the typical user journey and associated API calls when configuring a new station and recording daily nozzle readings.
+
+## Owner / Manager Station Setup
+```mermaid
+flowchart TD
+    login[Login] --> createStation[POST /api/v1/stations]
+    createStation --> createPump[POST /api/v1/pumps]
+    createPump --> createNozzle[POST /api/v1/nozzles]
+    createNozzle --> setPrice[POST /api/v1/fuel-prices]
+    setPrice --> ready[Station ready for readings]
+```
+
+## Attendant Daily Reading Entry
+```mermaid
+flowchart TD
+    alogin[Login] --> checkPrice[GET /api/v1/fuel-prices]
+    checkPrice --> canCreate[GET /api/v1/nozzle-readings/can-create/{nozzleId}]
+    canCreate -- Allowed --> record[POST /api/v1/nozzle-readings]
+    canCreate -- Not Allowed --> halt[Stop: finalize previous day]
+```
+
+These flows show the sequential API calls from initial station setup to daily nozzle reading entry. Reading creation generates sales automatically once the station hierarchy and fuel prices are in place.
+
+## Sale Calculation & Fuel Price Use
+```mermaid
+sequenceDiagram
+    participant Attendant
+    participant API
+    participant DB
+    Attendant->>API: POST /api/v1/nozzle-readings {reading: 10500}
+    API->>DB: lookup last reading
+    API->>DB: fetch current price
+    API->>API: delta = current - last
+    API->>API: amount = delta * price
+    API->>DB: insert sale record
+    API->>DB: update fuel_inventory
+    API-->>Attendant: 201 Created with sale summary
+```
+
+Example: if last reading was **10,000 L** and current reading is **10,500 L** at **₹102/L**, the generated sale has volume **500 L** and amount **₹51,000**.
+
+## Validation & Edge Cases
+```mermaid
+flowchart LR
+    start([POST /api/v1/nozzle-readings]) --> priceCheck{Fuel price exists?}
+    priceCheck -- No --> errorPrice[400 Missing price]
+    priceCheck -- Yes --> dayCheck{Previous day finalized?}
+    dayCheck -- No --> errorDay[409 Finalize previous day]
+    dayCheck -- Yes --> good[Create reading & sale]
+```
+
+## Analytics & Reconciliation Flow
+```mermaid
+flowchart TD
+    salesTbl[(sales)] --> reconAPI[POST /api/v1/reconciliations]
+    reconAPI --> reconTbl[(day_reconciliations)]
+    salesTbl --> analyticsAPI[GET /api/v1/analytics/station/{id}]
+    analyticsAPI --> dashboard[Dashboard metrics]
+```
+
+## Database Relations Overview
+```mermaid
+erDiagram
+    stations ||--o{ pumps : has
+    pumps ||--o{ nozzles : has
+    nozzles ||--o{ nozzle_readings : logs
+    nozzle_readings ||--o{ sales : generates
+    stations ||--o{ fuel_prices : pricing
+    sales ||--|{ day_reconciliations : aggregated_by
+```


### PR DESCRIPTION
## Summary
- expand user journey docs with sales calculation, validation cases and DB relationships
- document the step in `STEP_2_63_COMMAND.md`
- log the update in the changelog, phase summary and implementation index

## Testing
- `npm run test:unit` *(fails: unable to provision test DB)*

------
https://chatgpt.com/codex/tasks/task_e_6887ebc01e548320962fa130c19b19ad